### PR TITLE
Notes, performance...

### DIFF
--- a/lib/DesktopHome.dart
+++ b/lib/DesktopHome.dart
@@ -15,17 +15,11 @@ import 'package:LoliSnatcher/pages/SettingsPage.dart';
 import 'package:LoliSnatcher/SnatchHandler.dart';
 import 'package:LoliSnatcher/pages/SnatcherPage.dart';
 import 'package:LoliSnatcher/getPerms.dart';
-import 'package:LoliSnatcher/libBooru/BooruItem.dart';
 import 'package:LoliSnatcher/widgets/FlashElements.dart';
 import 'package:LoliSnatcher/widgets/TagSearchButton.dart';
+import 'package:LoliSnatcher/widgets/ResizableSplitView.dart';
 
-class DesktopHome extends StatefulWidget {
-  @override
-  _DesktopHomeState createState() => _DesktopHomeState();
-  DesktopHome();
-}
-
-class _DesktopHomeState extends State<DesktopHome> {
+class DesktopHome extends StatelessWidget {
   final SnatchHandler snatchHandler = Get.find<SnatchHandler>();
   final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
   final SearchHandler searchHandler = Get.find<SearchHandler>();
@@ -36,6 +30,7 @@ class _DesktopHomeState extends State<DesktopHome> {
       resizeToAvoidBottomInset: false,
       appBar: AppBar(
         toolbarHeight: 60,
+        backgroundColor: Get.theme.colorScheme.background,
         actions: <Widget>[
           Obx(() {
             if (settingsHandler.booruList.isNotEmpty && searchHandler.list.isNotEmpty) {
@@ -56,12 +51,11 @@ class _DesktopHomeState extends State<DesktopHome> {
               return const SizedBox();
             }
           }),
-
           Obx(() {
             if (settingsHandler.booruList.isNotEmpty && searchHandler.list.isNotEmpty) {
               return SettingsButton(
                 name: 'Snatcher',
-                icon: Icon(Icons.download),
+                icon: Icon(Icons.download, color: Get.theme.colorScheme.onBackground),
                 iconOnly: true,
                 page: () => SnatcherPage(),
               );
@@ -69,7 +63,6 @@ class _DesktopHomeState extends State<DesktopHome> {
               return const SizedBox();
             }
           }),
-
           Obx(() {
             if (settingsHandler.booruList.isEmpty || searchHandler.list.isEmpty) {
               return Center(child: Text('Add Boorus in Settings'));
@@ -77,50 +70,38 @@ class _DesktopHomeState extends State<DesktopHome> {
               return const SizedBox();
             }
           }),
-
           SettingsButton(
             name: 'Settings',
-            icon: Icon(Icons.settings),
+            icon: Icon(Icons.settings, color: Get.theme.colorScheme.onBackground),
             iconOnly: true,
             page: () => SettingsPage(),
           ),
-
           Obx(() {
-            if(searchHandler.list.isNotEmpty) {
+            if (searchHandler.list.isNotEmpty) {
               return Stack(
                 alignment: Alignment.center,
                 children: [
                   SettingsButton(
                     name: 'Save',
-                    icon: Icon(Icons.save),
+                    icon: Icon(Icons.save, color: Get.theme.colorScheme.onBackground),
                     iconOnly: true,
                     action: () {
                       getPerms();
                       // call a function to save the currently viewed image when the save button is pressed
-                      if (searchHandler.currentTab.selected.length > 0){
+                      if (searchHandler.currentTab.selected.length > 0) {
                         snatchHandler.queue(
-                          searchHandler.currentTab.getSelected(),
-                          searchHandler.currentTab.selectedBooru.value,
-                          settingsHandler.snatchCooldown
-                        );
+                            searchHandler.currentTab.getSelected(), searchHandler.currentTab.selectedBooru.value, settingsHandler.snatchCooldown);
                         searchHandler.currentTab.selected.value = [];
                       } else {
                         FlashElements.showSnackbar(
                           context: context,
-                          title: Text(
-                            "No items selected",
-                            style: TextStyle(fontSize: 20)
-                          ),
-                          overrideLeadingIconWidget: Text(
-                            " (」°ロ°)」 ",
-                            style: TextStyle(fontSize: 18)
-                          ),
+                          title: Text("No items selected", style: TextStyle(fontSize: 20)),
+                          overrideLeadingIconWidget: Text(" (」°ロ°)」 ", style: TextStyle(fontSize: 18)),
                         );
                       }
                     },
                   ),
-
-                  if(searchHandler.currentTab.selected.isNotEmpty)
+                  if (searchHandler.currentTab.selected.isNotEmpty)
                     Positioned(
                       child: Container(
                         width: 20,
@@ -132,87 +113,66 @@ class _DesktopHomeState extends State<DesktopHome> {
                         ),
                         child: Center(
                           child: FittedBox(
-                            child: Text(
-                              '${searchHandler.currentTab.selected.length}',
-                              style: TextStyle(color: Get.theme.colorScheme.onSecondary)
-                            ),
-                          )
-                        )
+                            child: Text('${searchHandler.currentTab.selected.length}', style: TextStyle(color: Get.theme.colorScheme.onSecondary)),
+                          ),
+                        ),
                       ),
                       right: 2,
                       bottom: 5,
-                    )
-                ]
+                    ),
+                ],
               );
             } else {
               return const SizedBox();
             }
           }),
-
         ],
       ),
       body: Center(
-        child: Row(
-          children: [
-            Expanded(
-              flex: 1,
-              child: Column(
-                children: [
-                  Expanded(
-                    child: Center(child: ImagePreviews()),
-                    flex: 2,
-                  ),
-                  Expanded(
-                    flex: 1,
-                    child: DesktopTagListener(),
-                  ),
-                ],
-              ),
-            ),
-            Expanded(
-              flex: 2,
-              child: Obx(() => searchHandler.list.isEmpty ? const SizedBox() : DesktopImageListener(searchHandler.currentTab)),
-            ),
-          ]
-        )
+        child: ResizableSplitView(
+          firstChild: ResizableSplitView(
+            firstChild: ImagePreviews(),
+            secondChild: DesktopTagListener(),
+            startRatio: 0.66,
+            minRatio: 0.33,
+            maxRatio: 1,
+            direction: SplitDirection.vertical,
+            onRatioChange: (double newRatio) {
+              // print('ratioChanged1 $newRatio');
+              // TODO save to settings, but debounce the saving to file
+            },
+          ),
+          secondChild: Obx(() => searchHandler.list.isEmpty ? const SizedBox() : DesktopImageListener(searchHandler.currentTab)),
+          startRatio: 0.33,
+          minRatio: 0.2,
+          maxRatio: 0.8,
+          onRatioChange: (double newRatio) {
+            // print('ratioChanged2 $newRatio');
+            // TODO save to settings, but debounce the saving to file
+          },
+        ),
       ),
     );
   }
 }
 
-
-class DesktopTagListener extends StatefulWidget {
-  DesktopTagListener();
-  @override
-  _DesktopTagListenerState createState() => _DesktopTagListenerState();
-}
-
-class _DesktopTagListenerState extends State<DesktopTagListener> {
-  SearchHandler searchHandler = Get.find<SearchHandler>();
+class DesktopTagListener extends StatelessWidget {
+  final SearchHandler searchHandler = Get.find<SearchHandler>();
 
   @override
   Widget build(BuildContext context) {
     return Obx(() {
-      if(searchHandler.list.isEmpty) {
-        return Center(
-          child: CircularProgressIndicator(
-            valueColor: AlwaysStoppedAnimation(Get.theme.colorScheme.secondary)
-          )
-        );
+      if (searchHandler.list.isEmpty) {
+        return Center(child: CircularProgressIndicator(valueColor: AlwaysStoppedAnimation(Get.theme.colorScheme.secondary)));
       }
 
-      BooruItem item = searchHandler.currentTab.currentItem.value;
-
       return Container(
-        child: TagView(item),
-        padding: EdgeInsets.all(5),
+        child: TagView(),
+        padding: EdgeInsets.all(2),
         decoration: BoxDecoration(
-            border: Border.all(color: Get.theme.colorScheme.secondary,width: 2),
+          border: Border.all(color: Get.theme.colorScheme.secondary, width: 1),
         ),
       );
     });
   }
 }
-
-
-

--- a/lib/MobileHome.dart
+++ b/lib/MobileHome.dart
@@ -12,22 +12,14 @@ import 'package:LoliSnatcher/SettingsHandler.dart';
 import 'package:LoliSnatcher/pages/SettingsPage.dart';
 import 'package:LoliSnatcher/SnatchHandler.dart';
 import 'package:LoliSnatcher/pages/SnatcherPage.dart';
-import 'package:LoliSnatcher/getPerms.dart';
-import 'package:LoliSnatcher/widgets/ActiveTitle.dart';
 import 'package:LoliSnatcher/widgets/FlashElements.dart';
 import 'package:LoliSnatcher/widgets/SettingsWidgets.dart';
 import 'package:LoliSnatcher/widgets/TagSearchButton.dart';
 import 'package:LoliSnatcher/widgets/MascotImage.dart';
-import 'package:LoliSnatcher/widgets/PageNumberDialog.dart';
 import 'package:LoliSnatcher/ServiceHandler.dart';
+import 'package:LoliSnatcher/widgets/MainAppbar.dart';
 
-class MobileHome extends StatefulWidget {
-  @override
-  _MobileHomeState createState() => _MobileHomeState();
-  MobileHome();
-}
-
-class _MobileHomeState extends State<MobileHome> {
+class MobileHome extends StatelessWidget {
   final SnatchHandler snatchHandler = Get.find<SnatchHandler>();
   final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
   final SearchHandler searchHandler = Get.find<SearchHandler>();
@@ -43,7 +35,7 @@ class _MobileHomeState extends State<MobileHome> {
     );
   }
 
-  Future<bool> _onBackPressed() async {
+  Future<bool> _onBackPressed(BuildContext context) async {
     final shouldPop = await showDialog(
       context: context,
       builder: (context) {
@@ -69,20 +61,6 @@ class _MobileHomeState extends State<MobileHome> {
     );
 
     return shouldPop ?? false; //shouldPop != null ? true : false;
-  }
-
-  Widget pageNumberButton() {
-    return IconButton(
-      icon: Icon(Icons.format_list_numbered),
-      onPressed: () {
-        showDialog(
-          context: context,
-          builder: (context) {
-            return PageNumberDialog();
-          }
-        );
-      },
-    );
   }
 
   Widget menuButton(InnerDrawerDirection direction) {
@@ -113,82 +91,20 @@ class _MobileHomeState extends State<MobileHome> {
     Widget scaff = Scaffold(
       key: mainScaffoldKey,
       resizeToAvoidBottomInset: true,
-      appBar: AppBar(
-        automaticallyImplyLeading: true,
-        title: ActiveTitle(),
-        leading: menuButton(InnerDrawerDirection.start),
-        actions: <Widget>[
-          // TODO needs more work and polish
-          // pageNumberButton(),
-
-          Obx(() {
-            if(searchHandler.list.isNotEmpty) {
-              return Stack(
-                alignment: Alignment.center,
-                children: [
-                  IconButton(
-                    icon: Icon(Icons.save),
-                    onPressed: () {
-                      getPerms();
-                      // call a function to save the currently viewed image when the save button is pressed
-                      if (searchHandler.currentTab.selected.length > 0){
-                        snatchHandler.queue(
-                          searchHandler.currentTab.getSelected(),
-                          searchHandler.currentTab.selectedBooru.value,
-                          settingsHandler.snatchCooldown
-                        );
-                        searchHandler.currentTab.selected.value = [];
-                      } else {
-                        FlashElements.showSnackbar(
-                          context: context,
-                          title: Text(
-                            "No items selected",
-                            style: TextStyle(fontSize: 20)
-                          ),
-                          overrideLeadingIconWidget: Text(
-                            " (」°ロ°)」 ",
-                            style: TextStyle(fontSize: 18)
-                          ),
-                        );
-                      }
-                    },
-                  ),
-
-                  if(searchHandler.currentTab.selected.isNotEmpty)
-                    Positioned(
-                      child: Container(
-                        width: 20,
-                        height: 20,
-                        decoration: BoxDecoration(
-                          color: Get.theme.colorScheme.secondary,
-                          border: Border.all(color: Get.theme.colorScheme.secondary, width: 1),
-                          borderRadius: BorderRadius.circular(15),
-                        ),
-                        child: Center(
-                          child: FittedBox(
-                            child: Text(
-                              '${searchHandler.currentTab.selected.length}',
-                              style: TextStyle(color: Get.theme.colorScheme.onSecondary)
-                            ),
-                          )
-                        )
-                      ),
-                      right: 2,
-                      bottom: 5,
-                    ),
-                ]
-              );
-            } else {
-              return const SizedBox.shrink();
-            }
-          }),
-
-          menuButton(InnerDrawerDirection.end),
-        ],
-      ),
-      body: WillPopScope(
-        onWillPop: _onBackPressed,
-        child: ImagePreviews(),
+      // appBar: MainAppBar(leading: menuButton(InnerDrawerDirection.start), trailing: menuButton(InnerDrawerDirection.end)),
+      extendBodyBehindAppBar: true,
+      body: SafeArea(
+        child: WillPopScope(
+          onWillPop: () {
+            return _onBackPressed(context);
+          },
+          child: Stack(
+            children: [
+              ImagePreviews(),
+              MainAppBar(leading: menuButton(InnerDrawerDirection.start), trailing: menuButton(InnerDrawerDirection.end)),
+            ],
+          )
+        ),
       ),
       // Old drawer stuff:
       // drawer: MainDrawer(key: mainDrawerKey),
@@ -271,7 +187,7 @@ class _MainDrawerState extends State<MainDrawer> {
             Obx(() {
               if (settingsHandler.booruList.isNotEmpty && searchHandler.list.isNotEmpty) {
                 return Container(
-                  margin: EdgeInsets.fromLTRB(5, 30, 5, 15),
+                  margin: EdgeInsets.fromLTRB(2, 15, 2, 15),
                   width: double.infinity,
                   child: Row(
                     mainAxisSize: MainAxisSize.max,
@@ -296,6 +212,7 @@ class _MainDrawerState extends State<MainDrawer> {
                   }
                 },
                 child: ListView(
+                  controller: ScrollController(), // needed to avoid exception when list overflows into a scrollable size
                   children: [
                     // TODO tabbox and booruselector cause lag when opening a drawer
                     TabBox(),

--- a/lib/RestartableProgressIndicator.dart
+++ b/lib/RestartableProgressIndicator.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:LoliSnatcher/TimedProgressController.dart';
 import 'package:get/get.dart';
 
@@ -13,8 +12,7 @@ class RestartableProgressIndicator extends StatefulWidget {
   RestartableProgressIndicator({
     Key? key,
     required this.controller,
-  }) : assert(controller != null),
-        super(key: key);
+  }) : super(key: key);
 
   @override
   _RestartableProgressIndicatorState createState() => _RestartableProgressIndicatorState();

--- a/lib/ServiceHandler.dart
+++ b/lib/ServiceHandler.dart
@@ -72,7 +72,7 @@ class ServiceHandler{
     } catch (e) {
       print(e);
     }
-    //new File(result+"/test.txt").create(recursive: true);
+    // File(result+"/test.txt").create(recursive: true);
     return result;
   }
   static Future<String> getImageSAFUri() async {
@@ -83,7 +83,7 @@ class ServiceHandler{
     } catch (e) {
       print(e);
     }
-    //new File(result+"/test.txt").create(recursive: true);
+    // File(result+"/test.txt").create(recursive: true);
     return result;
   }
   static Future<Uint8List?> getSAFFile(String contentUri) async {
@@ -94,7 +94,7 @@ class ServiceHandler{
     } catch (e) {
       print(e);
     }
-    //new File(result+"/test.txt").create(recursive: true);
+    // File(result+"/test.txt").create(recursive: true);
     return result;
   }
   static Future<String> getSAFFileExtension(String contentUri) async {
@@ -106,7 +106,7 @@ class ServiceHandler{
     } catch (e) {
       print(e);
     }
-    //new File(result+"/test.txt").create(recursive: true);
+    // File(result+"/test.txt").create(recursive: true);
     return result;
   }
 

--- a/lib/ViewUtils.dart
+++ b/lib/ViewUtils.dart
@@ -1,12 +1,8 @@
-
-import 'dart:math';
-import 'package:LoliSnatcher/libBooru/Booru.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
 
-import 'package:LoliSnatcher/SettingsHandler.dart';
 import 'package:LoliSnatcher/SearchGlobals.dart';
+import 'package:LoliSnatcher/libBooru/Booru.dart';
 
 class ViewUtils {
 
@@ -46,42 +42,6 @@ class ViewUtils {
         return Icons.play_disabled;
       default:
         return CupertinoIcons.question;
-    }
-  }
-
-  static void jumpToItem(int item, SearchGlobal searchGlobal, ScrollController gridController, BuildContext context) {
-    final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
-    
-    int? totalItems = searchGlobal.booruHandler.filteredFetched.length;
-    // print("jump to item called index is: $item");
-    if (totalItems > 0) {
-      double viewportHeight = gridController.position.viewportDimension;
-      double totalHeight = gridController.position.maxScrollExtent + viewportHeight;
-      int columnsCount = (MediaQuery.of(context).orientation == Orientation.portrait)
-          ? settingsHandler.portraitColumns
-          : settingsHandler.landscapeColumns;
-      int rowCount = (totalItems / columnsCount).ceil();
-      double rowHeight = totalHeight / rowCount;
-      double rowsPerViewport = viewportHeight / rowHeight;
-
-      int currentRow = (item / columnsCount).floor();
-      // scroll to the row of the current item
-      // but if we can't scroll to the top of this row (rows left < rowsPerViewport) - scroll to the max and trigger page load
-      bool isCloseToEdge = (rowCount - currentRow) <= rowsPerViewport;
-      double scrollToValue =
-      isCloseToEdge ? totalHeight : max((rowHeight * currentRow), 0.0);
-
-      // print('SCROLL CONTROLLER');
-      // print(widget.gridController.position);
-      // print(newValue);
-
-      //gridController.jumpTo(scrollToValue);
-      // gridController.animateTo(scrollToValue, duration: Duration(milliseconds: 300), curve: Curves.linear);
-      WidgetsBinding.instance!.addPostFrameCallback((_) {
-        if(gridController.hasClients){
-          gridController.animateTo(scrollToValue, duration: Duration(milliseconds: 300), curve: Curves.linear);
-        }
-      });
     }
   }
 }

--- a/lib/ViewerHandler.dart
+++ b/lib/ViewerHandler.dart
@@ -1,9 +1,11 @@
 // TODO media actions, video pause/mute... global controller
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:photo_view/photo_view.dart';
+
 import 'package:LoliSnatcher/widgets/MediaViewerBetter.dart';
 import 'package:LoliSnatcher/widgets/VideoApp.dart';
 import 'package:LoliSnatcher/widgets/VideoAppDesktop.dart';
-import 'package:flutter/material.dart';
-import 'package:get/get.dart';
 
 class ViewerHandler extends GetxController {
   // Keys to get states of all currently built viewers
@@ -44,15 +46,21 @@ class ViewerHandler extends GetxController {
   RxBool inViewer = false.obs; // is in viewerpage
   RxBool displayAppbar = true.obs; // is gallery toolbar visible
   RxBool isZoomed = false.obs; // is current item zoomed in
+  RxBool isLoaded = false.obs; // is current item loaded
+  Rx<PhotoViewControllerValue> viewState = Rx(PhotoViewControllerValue(position: Offset.zero, scale: null, rotation: 0, rotationFocusPoint: null)); // current view state
   RxBool isFullscreen = false.obs; // is in fullscreen (on mobile for videos through VideoApp)
   RxBool isDesktopFullscreen = false.obs; // is in fullscreen mode in DesktopHome
+
+  RxBool showNotes = true.obs;
 
   void resetState() {
     inViewer.value = false;
     displayAppbar.value = true;
     isZoomed.value = false;
+    isLoaded.value = false;
     isFullscreen.value = false;
     isDesktopFullscreen.value = false;
+    viewState.value = PhotoViewControllerValue(position: Offset.zero, scale: null, rotation: 0, rotationFocusPoint: null);
   }
 
   // Get zoom state of new current item
@@ -67,15 +75,21 @@ class ViewerHandler extends GetxController {
       switch (widget.runtimeType) {
         case MediaViewerBetter:
           isZoomed.value = state?.isZoomed ?? false;
+          isLoaded.value = state?.mainProvider != null;
           isFullscreen.value = false;
+          viewState.value = state?.viewController.value;
           break;
         case VideoApp:
           isZoomed.value = state?.isZoomed ?? false;
+          isLoaded.value = true;
           isFullscreen.value = state?.chewieController?.isFullScreen ?? false;
+          viewState.value = state?.viewController.value;
           break;
         case VideoAppDesktop:
           isZoomed.value = state?.isZoomed ?? false;
+          isLoaded.value = true;
           isFullscreen.value = false;
+          viewState.value = state?.viewController.value;
           break;
         default: break;
       }
@@ -94,15 +108,25 @@ class ViewerHandler extends GetxController {
   }
   void resetZoom() {
     dynamic state = currentKey.value?.currentState;
-    if(state != null) {
-      state.resetZoom?.call();
-    }
+    state?.resetZoom?.call();
   }
   void doubleTapZoom() {
     dynamic state = currentKey.value?.currentState;
-    if(state != null) {
-      state.doubleTapZoom?.call();
-    }
+    state?.doubleTapZoom?.call();
+  }
+
+  void setViewState(Key? key, PhotoViewControllerValue value) {
+    if(key == null) return;
+    if(currentKey.value != key) return;
+
+    viewState.value = value;
+  }
+
+  void setLoaded(Key? key, bool value) {
+    if(key == null) return;
+    if(currentKey.value != key) return;
+
+    isLoaded.value = value;
   }
 
 

--- a/lib/libBooru/AGNPHHandler.dart
+++ b/lib/libBooru/AGNPHHandler.dart
@@ -7,6 +7,8 @@ import 'BooruHandler.dart';
 import 'BooruItem.dart';
 import 'Booru.dart';
 
+// TODO no setTrackedValues?
+
 /**
  * Booru Handler for the gelbooru engine
  */
@@ -21,7 +23,7 @@ class AGNPHHandler extends BooruHandler{
    * This function will call a http get request using the tags and pagenumber parsed to it
    * it will then create a list of booruItems
    */
-  Future Search(String tags, int? pageNumCustom) async{
+  Future Search(String tags, int? pageNumCustom) async {
     tags = validateTags(tags);
     if (prevTags != tags){
       fetched.value = [];
@@ -40,7 +42,6 @@ class AGNPHHandler extends BooruHandler{
           locked.value = true;
         }
         prevTags = tags;
-        return fetched;
       } else {
         Logger.Inst().log("AGNPHHandler status is: ${response.statusCode}", "BooruHandler", "Search", LogTypes.booruHandlerFetchFailed);
         Logger.Inst().log("AGNPHHandler url is: $url", "BooruHandler", "Search", LogTypes.booruHandlerFetchFailed);
@@ -49,8 +50,9 @@ class AGNPHHandler extends BooruHandler{
     } catch(e) {
       Logger.Inst().log(e.toString(), "AGNPHHandler", "Search", LogTypes.exception);
       errorString.value = e.toString();
-      return fetched;
     }
+
+    return fetched;
   }
 
   // Slow af I have emailed the site admin to ask them to change their api.
@@ -76,7 +78,7 @@ class AGNPHHandler extends BooruHandler{
           if (sampleURL.isEmpty){
             sampleURL = fileURL;
           }
-          BooruItem result = new BooruItem(
+          BooruItem result = BooruItem(
             fileURL: fileURL,
             sampleURL: sampleURL,
             thumbnailURL: thumbnailURL,

--- a/lib/libBooru/Booru.dart
+++ b/lib/libBooru/Booru.dart
@@ -83,11 +83,11 @@ class Booru {
     Map<String, dynamic> json = jsonDecode(jsonString);
     this.name = json["name"].toString();
     this.type = json["type"].toString();
-    this.faviconURL = json["faviconURL"].toString();
+    this.faviconURL = json["faviconURL"]?.toString() ?? "";
     this.baseURL = json["baseURL"].toString();
-    this.defTags = json["defTags"].toString();
-    this.apiKey = json["apiKey"].toString();
-    this.userID = json["userID"].toString();
+    this.defTags = json["defTags"]?.toString() ?? "";
+    this.apiKey = json["apiKey"]?.toString() ?? "";
+    this.userID = json["userID"]?.toString() ?? "";
   }
 
   @override

--- a/lib/libBooru/BooruHandler.dart
+++ b/lib/libBooru/BooruHandler.dart
@@ -9,11 +9,10 @@ import 'package:LoliSnatcher/libBooru/BooruItem.dart';
 import 'package:LoliSnatcher/utilities/Logger.dart';
 import 'package:LoliSnatcher/SettingsHandler.dart';
 
-
 abstract class BooruHandler {
   // pagenum = -1 as "didn't load anything yet" state
   // gets set to higher number for special cases in handler factory
-  RxInt pageNum = (-1).obs; 
+  RxInt pageNum = (-1).obs;
   int limit = 20;
   String prevTags = "";
   RxBool locked = false.obs;
@@ -26,18 +25,18 @@ abstract class BooruHandler {
 
   bool tagSearchEnabled = true;
   bool hasSizeData = false;
-  BooruHandler(this.booru,this.limit);
+  BooruHandler(this.booru, this.limit);
 
   /**
    * This function will call a http get request using the tags and pagenumber parsed to it
    * it will then create a list of booruItems
    */
   Future Search(String tags, int? pageNumCustom) async {
-    if(pageNumCustom != null) {
+    if (pageNumCustom != null) {
       pageNum.value = pageNumCustom;
     }
     tags = validateTags(tags);
-    if (prevTags != tags){
+    if (prevTags != tags) {
       fetched.value = [];
     }
 
@@ -46,36 +45,54 @@ abstract class BooruHandler {
     try {
       int length = fetched.length;
       Uri uri = Uri.parse(url);
-      final response = await http.get(uri,headers: getHeaders());
+      final response = await http.get(uri, headers: getHeaders());
       if (response.statusCode == 200) {
         parseResponse(response);
         prevTags = tags;
-        if (fetched.length == length){locked.value = true;}
+        if (fetched.length == length) {
+          locked.value = true;
+        }
       } else {
         Logger.Inst().log("BooruHandler status is: ${response.statusCode}", "BooruHandler", "Search", LogTypes.booruHandlerFetchFailed);
         Logger.Inst().log("BooruHandler url is: $url", "BooruHandler", "Search", LogTypes.booruHandlerFetchFailed);
         Logger.Inst().log("BooruHandler url response is: ${response.body}", "BooruHandler", "Search", LogTypes.booruHandlerFetchFailed);
         errorString.value = response.statusCode.toString();
       }
-    } catch(e) {
+    } catch (e) {
       Logger.Inst().log(e.toString(), "BooruHandler", "Search", LogTypes.exception);
       errorString.value = e.toString();
-      // return fetched;
     }
 
     // print('Fetched: ${filteredFetched.length}');
     return fetched;
   }
 
-  void parseResponse(response){return;}
-  String validateTags(String tags){return tags;}
-  String? makePostURL(String id){}
-  String? makeURL(String tags){}
-  String? makeTagURL(String input){}
+  void parseResponse(response) {
+    return;
+  }
+
+  String validateTags(String tags) {
+    return tags;
+  }
+
+  String? makePostURL(String id) {}
+  String? makeURL(String tags) {}
+  String? makeTagURL(String input) {}
   tagSearch(String input) {}
 
   bool hasCommentsSupport = false;
-  fetchComments(String postID, int pageNum) {return [];}
+  fetchComments(String postID, int pageNum) {
+    return [];
+  }
+
+  // TODO
+  bool hasUpdateItemSupport = false;
+  updateItem(BooruItem item) {}
+
+  bool hasNotesSupport = false;
+  fetchNotes(String postID) {
+    return [];
+  }
 
   RxInt totalCount = 0.obs;
   Future<void> searchCount(String input) async {
@@ -83,12 +100,13 @@ abstract class BooruHandler {
     return;
   }
 
-  Map<String,String> getWebHeaders() {
-      return {"Accept": "text/html,application/xml,application/json", "user-agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:83.0) Gecko/20100101 Firefox/83.0"};
+  Map<String, String> getHeaders() {
+    return {
+      "Accept": "text/html,application/xml,application/json",
+      "user-agent": "LoliSnatcher_Droid/$verStr"
+    };
   }
-  Map<String,String> getHeaders(){
-    return {"Accept": "text/html,application/xml,application/json", "user-agent":"LoliSnatcher_Droid/$verStr"};
-  }
+
   String getDescription() {
     return '';
   }
@@ -97,7 +115,7 @@ abstract class BooruHandler {
     return [];
   }
 
-  void setupMerge(List<Booru> boorus){}
+  void setupMerge(List<Booru> boorus) {}
 
   //set the isSnatched and isFavourite booleans for a BooruItem in fetched
   Future<void> setTrackedValues(int fetchedIndex) async {
@@ -123,7 +141,7 @@ abstract class BooruHandler {
     // we need +1 to make sure we don't miss the last item, because sublist doesn't include the item with the end index
     // so this way we exceed the possible length of fetched to get it
 
-    if(diff == 0) {
+    if (diff == 0) {
       // do nothing if nothing was added
       return;
     }
@@ -133,9 +151,9 @@ abstract class BooruHandler {
 
     final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
     if (settingsHandler.favDbHandler.db != null && diff > 0) {
-      List<List<bool>> valuesList = await settingsHandler.favDbHandler.getMultipleTrackedValues(
-        fetched.sublist(fetchedIndexes.first, fetchedIndexes.last) //.map((e) => e.fileURL).toList()
-      );
+      List<List<bool>> valuesList = await settingsHandler.favDbHandler
+          .getMultipleTrackedValues(fetched.sublist(fetchedIndexes.first, fetchedIndexes.last) //.map((e) => e.fileURL).toList()
+              );
 
       valuesList.asMap().forEach((index, values) {
         fetched[fetchedIndexes[index]].isSnatched.value = values[0];
@@ -147,8 +165,6 @@ abstract class BooruHandler {
         // fetched[fetchedIndex].isLoved.value = tagLists[1].length > 0;
       });
     }
-
-
 
     return;
   }

--- a/lib/libBooru/BooruHandlerFactory.dart
+++ b/lib/libBooru/BooruHandlerFactory.dart
@@ -99,11 +99,11 @@ class BooruHandlerFactory {
           break;
         case("AGNPH"):
           pageNum = 0;
-          booruHandler = new AGNPHHandler(boorus[0], limit);
+          booruHandler = AGNPHHandler(boorus[0], limit);
           break;
         case("NyanPals"):
           pageNum = -1;
-          booruHandler = new NyanPalsHandler(boorus[0], limit);
+          booruHandler = NyanPalsHandler(boorus[0], limit);
           break;
         default:
           booruHandler = EmptyHandler(Booru(null, null, null, null, null), limit);

--- a/lib/libBooru/BooruItem.dart
+++ b/lib/libBooru/BooruItem.dart
@@ -1,21 +1,26 @@
 import 'dart:convert';
-import 'package:LoliSnatcher/Tools.dart';
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+
+import 'package:LoliSnatcher/Tools.dart';
+import 'package:LoliSnatcher/libBooru/NoteItem.dart';
 
 class BooruItem{
   late Key key;
   String fileURL, sampleURL, thumbnailURL, postURL;
   List<String> tagsList;
-  String? mediaType;
+  late String mediaType;
   RxnBool isSnatched = RxnBool(null), isFavourite = RxnBool(null);
   RxBool isHated = false.obs, isNoScale = false.obs;
 
   String? fileExt, serverId, rating, score, md5String, postDate, postDateFormat;
   List<String>? sources;
+  RxList<NoteItem> notes = RxList([]);
   bool? hasNotes, hasComments;
   double? fileWidth, fileHeight, sampleWidth, sampleHeight, previewWidth, previewHeight;
   int? fileSize;
+
   BooruItem({
     required this.fileURL,
     required this.sampleURL,
@@ -50,21 +55,41 @@ class BooruItem{
     }
     this.fileExt = this.fileExt != null ? this.fileExt : Tools.getFileExt(this.fileURL);
     this.fileExt = this.fileExt!.toLowerCase();
-    if (["jpg", "jpeg", "png", "webp"].any((val) => this.fileExt == val)) {
-      this.mediaType = "image";
-    } else if (["webm", "mp4"].any((val) => this.fileExt == val)) {
-      this.mediaType = "video";
-    } else if (["gif"].any((val) => this.fileExt == val)) {
-      this.mediaType = "animation";
-    } else if (["apng"].any((val) => this.fileExt == val)) {
-      this.mediaType = "not_supported_animation";
-    } else {
-      this.mediaType = "other";
+    switch (this.fileExt) {
+      case 'jpg':
+      case 'jpeg':
+      case 'png':
+      case 'webp':
+        this.mediaType = 'image';
+        break;
+
+      case 'mp4':
+      case 'webm':
+        this.mediaType = 'video';
+        break;
+
+      case 'gif':
+        this.mediaType = 'animation';
+        break;
+
+      case 'apng':
+        this.mediaType = 'not_supported_animation';
+        break;
+
+      default:
+        this.mediaType = 'unknown';
+        break;
     }
   }
+
   bool isVideo() {
-    return (this.mediaType == "video");
+    return this.mediaType == "video";
   }
+
+  bool isImage() {
+    return this.mediaType == "image" || this.mediaType == "animation" || this.mediaType == "not_supported_animation";
+  }
+
   Map toJSON() {
     return {
       "postURL": postURL,
@@ -75,8 +100,20 @@ class BooruItem{
       "fileExt": fileExt,
       "isFavourite": isFavourite.value,
       "isSnatched" : isSnatched.value,
+      "serverId": serverId,
+      "rating": rating,
+      "score": score,
+      "sources": sources,
+      "md5String": md5String,
+      "postDate": postDate,
+      "postDateFormat": postDateFormat,
     };
   }
+
+  String toString() {
+    return jsonEncode(this.toJSON());
+  }
+
   static BooruItem fromJSON(String jsonString){
     Map<String, dynamic> json = jsonDecode(jsonString);
     List<String> tags = [];
@@ -95,6 +132,20 @@ class BooruItem{
     );
     item.isFavourite.value = json["isFavourite"].toString() == "true" ? true : false;
     item.isSnatched.value = json["isSnatched"].toString() == "true"? true : false;
+    return item;
+  }
+
+  static BooruItem fromDBRow(dynamic row) {
+    BooruItem item = BooruItem(
+      fileURL: row["fileURL"].toString(),
+      sampleURL: row["sampleURL"].toString(),
+      thumbnailURL: row["thumbnailURL"].toString(),
+      // use custom separator to avoid conflicts with tags containing commas
+      tagsList: row["tags"].toString().split("@@@"),
+      postURL: row["postURL"].toString(),
+    );
+    item.isFavourite.value = Tools.intToBool(row["isFavourite"]) ;
+    item.isSnatched.value = Tools.intToBool(row["isSnatched"]);
     return item;
   }
 }

--- a/lib/libBooru/FavouritesHandler.dart
+++ b/lib/libBooru/FavouritesHandler.dart
@@ -8,26 +8,23 @@ class FavouritesHandler extends BooruHandler{
   FavouritesHandler(Booru booru,int limit): super(booru,limit);
 
   @override
-  Future Search(String tags, int? pageNumCustom) async{
+  Future Search(String tags, int? pageNumCustom) async {
     final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
 
     int length = fetched.length;
-    if (prevTags != tags){
+    if (prevTags != tags) {
       fetched.value = [];
     }
 
     fetched.addAll(await settingsHandler.dbHandler.searchDB(tags, fetched.length.toString(), limit.toString(), "DESC", "Favourites"));
-    print("dbhandler fetched length is $length");
+    print("dbhandler fetched length is ${fetched.length}");
     prevTags = tags;
-    if (fetched.isEmpty){
+
+    if (fetched.isEmpty || fetched.length == length) {
       Logger.Inst().log("dbhandler dbLocked", "FavouritesHandler", "search", LogTypes.booruHandlerInfo);
       locked.value = true;
-    } else {
-      if (fetched.length == length){
-        Logger.Inst().log("dbhandler dbLocked", "FavouritesHandler", "search", LogTypes.booruHandlerInfo);
-        locked.value = true;
-      }
     }
+
     return fetched;
   }
 

--- a/lib/libBooru/HydrusHandler.dart
+++ b/lib/libBooru/HydrusHandler.dart
@@ -60,83 +60,84 @@ class HydrusHandler extends BooruHandler{
     } else {
       return await getResultsPage(pageNum);
     }
-    }
+  }
 
-    Future getResultsPage(pageNum) async{
-      try {
-        int pageMax = (_fileIDs.length > limit ? (_fileIDs.length / limit).ceil() : 1);
-        if (pageNum.value >= pageMax){
-          locked.value = true;
-        } else {
-          int lowerBound = ((pageNum.value < 1) ? 0 : pageNum.value * limit);
-          int upperBound = (pageNum.value + 1< pageMax) ? (lowerBound + limit) : _fileIDs.length;
-          String fileIDString = '[';
-          for (int i = lowerBound; i < upperBound ; i++){
-            fileIDString += _fileIDs[i].toString();
-            if(i != upperBound - 1) {fileIDString +=',';}
-          }
-          fileIDString += ']';
-          String url = "${booru.baseURL}/get_files/file_metadata?file_ids=$fileIDString";
-          Uri uri = Uri.parse(url);
-          final response = await http.get(uri,headers: {"Accept": "text/html,application/xml", "user-agent":"LoliSnatcher_Droid/$verStr","Hydrus-Client-API-Access-Key" : booru.apiKey!});
-          if (response.statusCode == 200) {
-            var parsedResponse = jsonDecode(response.body);
-            Logger.Inst().log(response.body, "HydrusHandler", "getResultsPage", LogTypes.booruHandlerRawFetched);
-
-            List<BooruItem> newItems = [];
-            for (int i = 0; i < parsedResponse['metadata'].length; i++) {
-                List<String> tagList = [];
-                var responseTags;
-                //@seniorm0ment
-                if (parsedResponse['metadata'][i]['service_names_to_statuses_to_display_tags']['all known tags'] != null) {
-                  responseTags = (parsedResponse['metadata'][i]['service_names_to_statuses_to_display_tags']['all known tags']['0'] == null) ? parsedResponse['metadata'][i]['service_names_to_statuses_to_display_tags']['all known tags']['1'] : parsedResponse['metadata'][i]['service_names_to_statuses_to_display_tags']['all known tags']['0'];
-                }
-                if(parsedResponse['metadata'][i]['service_names_to_statuses_to_tags']['all known tags'] != null && responseTags == null){
-                  responseTags = (parsedResponse['metadata'][i]['service_names_to_statuses_to_tags']['all known tags']['0'] == null) ? parsedResponse['metadata'][i]['service_names_to_statuses_to_tags']['all known tags']['1'] : parsedResponse['metadata'][i]['service_names_to_statuses_to_tags']['all known tags']['0'];
-                }
-                if (responseTags != null){
-                  for (int x = 0; x < responseTags.length; x++){
-                    tagList.add(responseTags[x].toString());
-                  }
-                }
-                if (parsedResponse['metadata'][i]['file_id'] != null){
-                  List dynKnownUrls = parsedResponse['metadata'][i]['known_urls'];
-                  List<String> knownUrls = [];
-                  if (dynKnownUrls.isNotEmpty){
-                    dynKnownUrls.forEach((element) {
-                      knownUrls.add(element.toString());
-                    });
-                  }
-                  BooruItem item = BooruItem(
-                    fileURL: "${booru.baseURL}/get_files/file?file_id=${parsedResponse['metadata'][i]['file_id']}&Hydrus-Client-API-Access-Key=${booru.apiKey}",
-                    sampleURL: "${booru.baseURL}/get_files/thumbnail?file_id=${parsedResponse['metadata'][i]['file_id']}&Hydrus-Client-API-Access-Key=${booru.apiKey}",
-                    thumbnailURL: "${booru.baseURL}/get_files/thumbnail?file_id=${parsedResponse['metadata'][i]['file_id']}&Hydrus-Client-API-Access-Key=${booru.apiKey}",
-                    tagsList: tagList,
-                    postURL: '',
-                    fileExt: parsedResponse['metadata'][i]['ext'].toString().substring(1),
-                    fileWidth: parsedResponse['metadata'][i]['width'].toDouble(),
-                    fileHeight: parsedResponse['metadata'][i]['height'].toDouble(),
-                    md5String: parsedResponse['metadata'][i]['hash'],
-                    sources: knownUrls,
-                  );
-
-                  newItems.add(item);
-                }
-            }
-
-            int lengthBefore = fetched.length;
-            fetched.addAll(newItems);
-            setMultipleTrackedValues(lengthBefore, fetched.length);
-            return fetched;
-          } else {
-            Logger.Inst().log("Getting metadata failed", "HydrusHandler", "getResultsPage", LogTypes.booruHandlerInfo);
-          }
+  Future getResultsPage(pageNum) async{
+    try {
+      int pageMax = (_fileIDs.length > limit ? (_fileIDs.length / limit).ceil() : 1);
+      if (pageNum.value >= pageMax){
+        locked.value = true;
+      } else {
+        int lowerBound = ((pageNum.value < 1) ? 0 : pageNum.value * limit);
+        int upperBound = (pageNum.value + 1< pageMax) ? (lowerBound + limit) : _fileIDs.length;
+        String fileIDString = '[';
+        for (int i = lowerBound; i < upperBound ; i++){
+          fileIDString += _fileIDs[i].toString();
+          if(i != upperBound - 1) {fileIDString +=',';}
         }
-      }catch(e){
-        Logger.Inst().log(e.toString(), "HydrusHandler", "getResultsPage", LogTypes.exception);
+        fileIDString += ']';
+        String url = "${booru.baseURL}/get_files/file_metadata?file_ids=$fileIDString";
+        Uri uri = Uri.parse(url);
+        final response = await http.get(uri,headers: {"Accept": "text/html,application/xml", "user-agent":"LoliSnatcher_Droid/$verStr","Hydrus-Client-API-Access-Key" : booru.apiKey!});
+        if (response.statusCode == 200) {
+          var parsedResponse = jsonDecode(response.body);
+          Logger.Inst().log(response.body, "HydrusHandler", "getResultsPage", LogTypes.booruHandlerRawFetched);
+
+          List<BooruItem> newItems = [];
+          for (int i = 0; i < parsedResponse['metadata'].length; i++) {
+              List<String> tagList = [];
+              var responseTags;
+              //@seniorm0ment
+              if (parsedResponse['metadata'][i]['service_names_to_statuses_to_display_tags']['all known tags'] != null) {
+                responseTags = (parsedResponse['metadata'][i]['service_names_to_statuses_to_display_tags']['all known tags']['0'] == null) ? parsedResponse['metadata'][i]['service_names_to_statuses_to_display_tags']['all known tags']['1'] : parsedResponse['metadata'][i]['service_names_to_statuses_to_display_tags']['all known tags']['0'];
+              }
+              if(parsedResponse['metadata'][i]['service_names_to_statuses_to_tags']['all known tags'] != null && responseTags == null){
+                responseTags = (parsedResponse['metadata'][i]['service_names_to_statuses_to_tags']['all known tags']['0'] == null) ? parsedResponse['metadata'][i]['service_names_to_statuses_to_tags']['all known tags']['1'] : parsedResponse['metadata'][i]['service_names_to_statuses_to_tags']['all known tags']['0'];
+              }
+              if (responseTags != null){
+                for (int x = 0; x < responseTags.length; x++){
+                  tagList.add(responseTags[x].toString());
+                }
+              }
+              if (parsedResponse['metadata'][i]['file_id'] != null){
+                List dynKnownUrls = parsedResponse['metadata'][i]['known_urls'];
+                List<String> knownUrls = [];
+                if (dynKnownUrls.isNotEmpty){
+                  dynKnownUrls.forEach((element) {
+                    knownUrls.add(element.toString());
+                  });
+                }
+                BooruItem item = BooruItem(
+                  fileURL: "${booru.baseURL}/get_files/file?file_id=${parsedResponse['metadata'][i]['file_id']}&Hydrus-Client-API-Access-Key=${booru.apiKey}",
+                  sampleURL: "${booru.baseURL}/get_files/thumbnail?file_id=${parsedResponse['metadata'][i]['file_id']}&Hydrus-Client-API-Access-Key=${booru.apiKey}",
+                  thumbnailURL: "${booru.baseURL}/get_files/thumbnail?file_id=${parsedResponse['metadata'][i]['file_id']}&Hydrus-Client-API-Access-Key=${booru.apiKey}",
+                  tagsList: tagList,
+                  postURL: '',
+                  fileExt: parsedResponse['metadata'][i]['ext'].toString().substring(1),
+                  fileWidth: parsedResponse['metadata'][i]['width'].toDouble(),
+                  fileHeight: parsedResponse['metadata'][i]['height'].toDouble(),
+                  md5String: parsedResponse['metadata'][i]['hash'],
+                  sources: knownUrls,
+                );
+
+                newItems.add(item);
+              }
+          }
+
+          int lengthBefore = fetched.length;
+          fetched.addAll(newItems);
+          setMultipleTrackedValues(lengthBefore, fetched.length);
+          return fetched;
+        } else {
+          Logger.Inst().log("Getting metadata failed", "HydrusHandler", "getResultsPage", LogTypes.booruHandlerInfo);
+        }
       }
-      return fetched;
+    }catch(e){
+      Logger.Inst().log(e.toString(), "HydrusHandler", "getResultsPage", LogTypes.exception);
     }
+    return fetched;
+  }
+
   Future addURL(BooruItem item) async{
     try {
       String url = "${booru.baseURL}/add_urls/add_url";
@@ -185,40 +186,42 @@ class HydrusHandler extends BooruHandler{
     }
     return fetched;
   }
-    Future getAccessKey() async{
-      String url = "${booru.baseURL}/request_new_permissions?name=LoliSnatcher&basic_permissions=[3,0,2]";
-      Logger.Inst().log("Requesting key: " + url, "HydrusHandler", "getAccessKey", LogTypes.booruHandlerInfo);
-      try {
-        Uri uri = Uri.parse(url);
-        final response = await http.get(uri,headers: {"Accept": "text/html,application/xml", "user-agent":"LoliSnatcher_Droid/$verStr","Hydrus-Client-API-Access-Key" : booru.apiKey!});
-        if (response.statusCode == 200) {
-          var parsedResponse = jsonDecode(response.body);
-          Logger.Inst().log("Key Request Successful: " + parsedResponse['access_key'].toString(), "HydrusHandler", "getAccessKey", LogTypes.booruHandlerInfo);
-          return parsedResponse['access_key'].toString();
-        } else {
-          Logger.Inst().log("Key Request Failed: " + response.statusCode.toString(), "HydrusHandler", "getAccessKey", LogTypes.booruHandlerInfo);
-          Logger.Inst().log(response.body, "HydrusHandler", "getAccessKey", LogTypes.booruHandlerInfo);
-        }
-      } catch (e){
-        Logger.Inst().log(e.toString(), "HydrusHandler", "getAccessKey", LogTypes.exception);
-      }
-      return "";
-    }
 
-    // This will create a url for the http request
-    String makeURL(String tags){
-      String tag;
-      if (tags.isEmpty){
-        tag = "[]";
-      } else if (tags.contains(",")){
-        tag = jsonEncode(tags.split(","));
+  Future getAccessKey() async {
+    String url = "${booru.baseURL}/request_new_permissions?name=LoliSnatcher&basic_permissions=[3,0,2]";
+    Logger.Inst().log("Requesting key: " + url, "HydrusHandler", "getAccessKey", LogTypes.booruHandlerInfo);
+    try {
+      Uri uri = Uri.parse(url);
+      final response = await http.get(uri,headers: {"Accept": "text/html,application/xml", "user-agent":"LoliSnatcher_Droid/$verStr","Hydrus-Client-API-Access-Key" : booru.apiKey!});
+      if (response.statusCode == 200) {
+        var parsedResponse = jsonDecode(response.body);
+        Logger.Inst().log("Key Request Successful: " + parsedResponse['access_key'].toString(), "HydrusHandler", "getAccessKey", LogTypes.booruHandlerInfo);
+        return parsedResponse['access_key'].toString();
       } else {
-        tag = "[${jsonEncode(tags)}]";
+        Logger.Inst().log("Key Request Failed: " + response.statusCode.toString(), "HydrusHandler", "getAccessKey", LogTypes.booruHandlerInfo);
+        Logger.Inst().log(response.body, "HydrusHandler", "getAccessKey", LogTypes.booruHandlerInfo);
       }
-      return "${booru.baseURL}/get_files/search_files?tags=$tag";
+    } catch (e){
+      Logger.Inst().log(e.toString(), "HydrusHandler", "getAccessKey", LogTypes.exception);
     }
-    String makeTagURL(String input){
-      return "${booru.baseURL}/index.php?page=dapi&s=tag&q=index&name_pattern=$input%&limit=10";
+    return "";
+  }
+
+  // This will create a url for the http request
+  String makeURL(String tags) {
+    String tag;
+    if (tags.isEmpty){
+      tag = "[]";
+    } else if (tags.contains(",")){
+      tag = jsonEncode(tags.split(","));
+    } else {
+      tag = "[${jsonEncode(tags)}]";
     }
+    return "${booru.baseURL}/get_files/search_files?tags=$tag";
+  }
+
+  String makeTagURL(String input){
+    return "${booru.baseURL}/index.php?page=dapi&s=tag&q=index&name_pattern=$input%&limit=10";
+  }
 
 }

--- a/lib/libBooru/InkBunnyHandler.dart
+++ b/lib/libBooru/InkBunnyHandler.dart
@@ -68,7 +68,7 @@ class InkBunnyHandler extends BooruHandler{
    * This function will call a http get request using the tags and pagenumber parsed to it
    * it will then create a list of booruItems
    */
-  Future Search(String tags, int? pageNumCustom) async{
+  Future Search(String tags, int? pageNumCustom) async {
     if (sessionToken.isEmpty){
       bool gotToken = await setSessionToken();
       if (!gotToken){
@@ -95,7 +95,6 @@ class InkBunnyHandler extends BooruHandler{
           prevTags = tags;
         }
         if (fetched.length == length){locked.value = true;}
-        return fetched;
       } else {
         Logger.Inst().log("InkBunnyHandler status is: ${response.statusCode}", "BooruHandler", "Search", LogTypes.booruHandlerFetchFailed);
         Logger.Inst().log("InkBunnyHandler url is: $url", "BooruHandler", "Search", LogTypes.booruHandlerFetchFailed);
@@ -104,8 +103,9 @@ class InkBunnyHandler extends BooruHandler{
     } catch(e) {
       Logger.Inst().log(e.toString(), "InkBunnyHandler", "Search", LogTypes.exception);
       errorString.value = e.toString();
-      return fetched;
     }
+
+    return fetched;
   }
 
   Future getSubmissionResponse(response) async{

--- a/lib/libBooru/LoliSync.dart
+++ b/lib/libBooru/LoliSync.dart
@@ -1,25 +1,35 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 
+import 'package:LoliSnatcher/SearchGlobals.dart';
 import 'package:LoliSnatcher/ServiceHandler.dart';
 import 'package:LoliSnatcher/SettingsHandler.dart';
 import 'package:LoliSnatcher/libBooru/Booru.dart';
 import 'package:LoliSnatcher/utilities/Logger.dart';
 import 'package:LoliSnatcher/widgets/FlashElements.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'BooruItem.dart';
 
 class LoliSync{
-  String ip = "";
-  int port = 1234;
+  String ip = "127.0.0.1";
+  int port = 8080;
+
   int amount = -1;
   int current = -1;
+
   var server;
   bool syncKilled = false;
 
-  Stream<String> startServer(SettingsHandler settingsHandler, String? ipOverride, String? portOverride) async* {
-    ip = ipOverride ?? await ServiceHandler.getIP();
-    port = int.tryParse(portOverride ?? '1234') ?? 1234;
+  Stream<String> startServer(String? ipOverride, String? portOverride) async* {
+    final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
+
+    String newIp = ipOverride ?? await ServiceHandler.getIP();
+    int newPort = int.tryParse(portOverride ?? '8080') ?? 8080;
+
+    this.ip = newIp;
+    this.port = newPort;
     server = await HttpServer.bind(ip, port);
 
     yield "Server active at $ip:$port";
@@ -34,6 +44,9 @@ class LoliSync{
           break;
         case("/lolisync/booru"):
           yield await storeBooru(req, settingsHandler);
+          break;
+        case("/lolisync/tabs"):
+          yield await storeTabs(req, settingsHandler);
           break;
         case("/lolisync/test"):
           yield 'Test';
@@ -135,7 +148,43 @@ class LoliSync{
     req.response.write("Invalid Query");
     return "Something went wrong";
   }
-  void killServer() async{
+
+  Future<String> storeTabs(var req, SettingsHandler settingsHandler) async {
+    final SearchHandler searchHandler = Get.find<SearchHandler>();
+    if (req.method == 'POST') {
+      try {
+        Logger.Inst().log("request to update tabs recieved", "LoliSync", "storeTabs", LogTypes.loliSyncInfo);
+        String content = await utf8.decoder.bind(req).join(); /*2*/
+        String mode = req.uri.queryParameters["mode"]!;
+        String? tabsString = jsonDecode(content)?["tabs"];
+        // print('tabsString: $tabsString');
+        // print('mode: $mode');
+        if(tabsString != null && tabsString.isNotEmpty) {
+          if(mode == 'Merge') {
+            searchHandler.mergeTabs(tabsString);
+          } else if(mode == 'Replace') {
+            searchHandler.replaceTabs(tabsString);
+          }
+        }
+
+        req.response.statusCode = 200;
+        req.response.write("Tabs Sent");
+        return "Tabs Saved";
+      } catch (e) {
+        Logger.Inst().log(e.toString(), "LoliSync", "storeTabs", LogTypes.exception);
+      }
+    } else {
+      req.response.statusCode = 404;
+      req.response.write("Invalid Query");
+      return "Invalid Query";
+    }
+    return "Something went wrong";
+  }
+
+
+
+
+  void killServer() async {
     await server.close();
     FlashElements.showSnackbar(
       title: Text(
@@ -153,9 +202,9 @@ class LoliSync{
     syncKilled = true;
   }
 
-  Future<String> sendBooruItem(BooruItem item, String ip, String port, int favouritesCount, int current) async{
+  Future<String> sendBooruItem(BooruItem item, int favouritesCount, int current) async {
     Logger.Inst().log("Sending item $current / $favouritesCount", "LoliSync", "sendBooruItem", LogTypes.loliSyncInfo);
-    HttpClientRequest request = await HttpClient().post(ip, int.parse(port), "/lolisync/booruitem?amount=$favouritesCount&current=$current")
+    HttpClientRequest request = await HttpClient().post(ip, port, "/lolisync/booruitem?amount=$favouritesCount&current=$current")
       ..headers.contentType = ContentType.json
       ..write(jsonEncode(item.toJSON())); /*3*/
     HttpClientResponse response = await request.close();
@@ -163,9 +212,9 @@ class LoliSync{
     return responseStr;
   }
 
-  Future<String> sendSettings(Map settingsJSON, String ip, String port) async{
+  Future<String> sendSettings(Map settingsJSON) async {
     Logger.Inst().log("Sending settings $settingsJSON", "LoliSync", "sendSettings", LogTypes.loliSyncInfo);
-    HttpClientRequest request = await HttpClient().post(ip, int.parse(port), "/lolisync/settings")
+    HttpClientRequest request = await HttpClient().post(ip, port, "/lolisync/settings")
       ..headers.contentType = ContentType.json
       ..write(jsonEncode(settingsJSON));
     HttpClientResponse response = await request.close();
@@ -173,9 +222,9 @@ class LoliSync{
     return responseStr;
   }
 
-  Future<String> sendBooru(Booru booru, String ip, String port, int booruCount, int current) async{
+  Future<String> sendBooru(Booru booru, int booruCount, int current) async {
     Logger.Inst().log("Sending item $current / $booruCount", "LoliSync", "sendBooru", LogTypes.loliSyncInfo);
-    HttpClientRequest request = await HttpClient().post(ip, int.parse(port), "/lolisync/booru?amount=$booruCount&current=$current")
+    HttpClientRequest request = await HttpClient().post(ip, port, "/lolisync/booru?amount=$booruCount&current=$current")
       ..headers.contentType = ContentType.json
       ..write(jsonEncode(booru.toJSON()));
     HttpClientResponse response = await request.close();
@@ -183,8 +232,46 @@ class LoliSync{
     return responseStr;
   }
 
-  Stream<String> startSync(SettingsHandler settingsHandler, String ip, String port, List<String> toSync) async*{
+  Future<String> sendTabs(String? tabsString, String mode) async {
+    Logger.Inst().log("Sending tabs $tabsString", "LoliSync", "sendTabs", LogTypes.loliSyncInfo);
+    HttpClientRequest request = await HttpClient().post(ip, port, "/lolisync/tabs?mode=$mode")
+      ..headers.contentType = ContentType.json
+      ..write(jsonEncode({
+        "tabs": tabsString
+      }));
+    HttpClientResponse response = await request.close();
+    String responseStr = await utf8.decoder.bind(response).join();
+    return responseStr;
+  }
+
+  Future<String> sendTest() async {
+    Logger.Inst().log("Sending test", "LoliSync", "sendTabs", LogTypes.loliSyncInfo);
+    HttpClientRequest request = await HttpClient().post(ip, port, "/lolisync/test");
+    HttpClientResponse response = await request.close();
+    if(response.statusCode != 200) {
+      FlashElements.showSnackbar(
+        title: Text(
+          "Test error: ${response.statusCode} ${response.reasonPhrase}",
+          style: TextStyle(fontSize: 20)
+        ),
+        leadingIcon: Icons.warning_amber,
+        leadingIconColor: Colors.red,
+        sideColor: Colors.red,
+      );
+      return "Test error";
+    } else {
+      return 'Test OK';
+    }
+  }
+
+  Stream<String> startSync(String ipOverride, String portOverride, List<String> toSync, int favSkip, String tabsMode) async* {
+    final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
+    final SearchHandler searchHandler = Get.find<SearchHandler>();
+
+    this.ip = ipOverride;
+    this.port = int.tryParse(portOverride) ?? 8080;
     final String address = '$ip:$port';
+
     for (int i = 0; i < toSync.length; i++) {
       switch(toSync.elementAt(i)) {
         case "Favourites":
@@ -193,16 +280,21 @@ class LoliSync{
           if (favouritesCount > 0) {
             int limit = 100;
             int ceiling = (favouritesCount / limit).ceil();
-            for(int i=0; i < ceiling; i++){
+
+            // If favSkip is set, start from skipAmount/limit, but limitted to (last 100 items (ceiling - 1))
+            int startFrom = min((ceiling - 1), (favSkip == 0 ? 0 : (favSkip / limit).floor()));
+
+            for(int i = startFrom; i < ceiling; i++) {
               if (!syncKilled) {
                 int offset = i * limit;
+                // TODO rework to send only missing ones?
                 List<BooruItem> fetched = await settingsHandler.dbHandler.searchDB("", offset.toString(), limit.toString(), "ASC", "loliSyncFav");
                 Logger.Inst().log("fetched is ${fetched.length} i is $i", "LoliSync", "startSync", LogTypes.loliSyncInfo);
                 for (int x = 0; x < fetched.length; x++){
                   int count = offset + x;
                   if (count < favouritesCount) {
                     // TODO send in batches, not in singles
-                    String resp = await sendBooruItem(fetched.elementAt(x), ip, port, favouritesCount, count);
+                    String resp = await sendBooruItem(fetched.elementAt(x), favouritesCount, count);
                     yield "$count / $favouritesCount - $resp";
                   } else {
                     Logger.Inst().log("skipping", "LoliSync", "startSync", LogTypes.loliSyncInfo);
@@ -221,7 +313,7 @@ class LoliSync{
           settingsHandler.deviceSpecificSettings.forEach((element) {
             settingsJSON.remove(element);
           });
-          String resp = await sendSettings(settingsJSON, ip, port);
+          String resp = await sendSettings(settingsJSON);
           yield resp;
           break;
         case "Booru":
@@ -231,7 +323,7 @@ class LoliSync{
             for (int i = 0; i < booruCount; i++){
               if (!syncKilled){
                 if (i < booruCount){
-                  String resp = await sendBooru(settingsHandler.booruList.elementAt(i), ip, port, booruCount, i);
+                  String resp = await sendBooru(settingsHandler.booruList.elementAt(i), booruCount, i);
                   yield "$i / $booruCount - $resp";
                 } else {
                   Logger.Inst().log("skipping", "LoliSync", "startSync", LogTypes.loliSyncInfo);
@@ -242,6 +334,11 @@ class LoliSync{
           } else {
             yield "No Booru Configs";
           }
+          break;
+        case "Tabs":
+          yield "Sync Starting $address";
+          String resp = await sendTabs(searchHandler.getBackupString(), tabsMode);
+          yield resp;
           break;
       }
     }

--- a/lib/libBooru/NoteItem.dart
+++ b/lib/libBooru/NoteItem.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+
+class NoteItem {
+  String? id, postID, content;
+  int posX, posY, width, height;
+
+  NoteItem({
+    this.id,
+    required this.postID,
+    required this.content,
+    required this.posX,
+    required this.posY,
+    required this.width,
+    required this.height,
+  });
+
+  Map toJSON() {
+    return {
+      'id': id,
+      'postID': postID,
+      'content': content,
+      'posX': posX,
+      'posY': posY,
+      'width': width,
+      'height': height,
+    };
+  }
+
+  static NoteItem fromJSON(String jsonString) {
+    Map<String, dynamic> json = jsonDecode(jsonString);
+    return NoteItem(
+      id: json['id'] as String,
+      postID: json['postID'] as String,
+      content: json['content'] as String,
+      posX: json['posX'] as int,
+      posY: json['posY'] as int,
+      width: json['width'] as int,
+      height: json['height'] as int,
+    );
+  }
+}

--- a/lib/libBooru/NyanPalsHandler.dart
+++ b/lib/libBooru/NyanPalsHandler.dart
@@ -50,7 +50,7 @@ class NyanPalsHandler extends BooruHandler{
       );
 
       thumbURL = booru.baseURL! + "/img/pettankontent/";
-      if (item.mediaType == "video"){
+      if (item.mediaType == "video") {
         thumbURL = thumbURL + item.md5String! + ".mp4";
       } else if (item.mediaType == "animation") {
         thumbURL = thumbURL + "_" + item.md5String! + ".gif";
@@ -60,7 +60,7 @@ class NyanPalsHandler extends BooruHandler{
       item.thumbnailURL = thumbURL;
 
       // video player cant do vp9 and dies
-      if (item.mediaType != "video"){
+      if (item.mediaType != "video") {
         newItems.add(item);
       }
     }

--- a/lib/libBooru/ShimmieHandler.dart
+++ b/lib/libBooru/ShimmieHandler.dart
@@ -28,6 +28,14 @@ class ShimmieHandler extends BooruHandler{
   }
 
   @override
+  Map<String,String> getHeaders() {
+    return {
+      "Accept": "text/html,application/xml,application/json",
+      "user-agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:83.0) Gecko/20100101 Firefox/83.0"
+    };
+  }
+
+  @override
   void parseResponse(response){
     var parsedResponse = xml.parse(response.body);
     /**
@@ -109,7 +117,7 @@ class ShimmieHandler extends BooruHandler{
     Logger.Inst().log("shimmie tag search $input $url", "ShimmieHandler", "tagSearch", LogTypes.booruHandlerInfo);
     try {
       Uri uri = Uri.parse(url);
-      final response = await http.get(uri,headers: getWebHeaders());
+      final response = await http.get(uri, headers: getHeaders());
       // 200 is the success http response code
       if (response.statusCode == 200) {
         searchTags = response.body.substring(1,(response.body.length - 1)).replaceAll(RegExp('(\:.([0-9])+)'), "").replaceAll("\"", "").split(",");
@@ -126,7 +134,7 @@ class ShimmieHandler extends BooruHandler{
       String url = makeURL(input);
       try {
         Uri uri = Uri.parse(url);
-        final response = await http.get(uri, headers: getWebHeaders());
+        final response = await http.get(uri, headers: getHeaders());
         // 200 is the success http response code
         if (response.statusCode == 200) {
           var parsedResponse = xml.parse(response.body);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,14 +2,11 @@ import 'dart:async';
 import 'dart:ui';
 import 'dart:io';
 
-import 'package:LoliSnatcher/libBooru/Booru.dart';
-import 'package:LoliSnatcher/pages/settings/BooruEditPage.dart';
-import 'package:LoliSnatcher/utilities/Logger.dart';
-import 'package:LoliSnatcher/widgets/SettingsWidgets.dart';
 import 'package:dart_vlc/dart_vlc.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart' show SchedulerBinding;
 import 'package:get/get.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:statsfl/statsfl.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -26,6 +23,10 @@ import 'package:LoliSnatcher/MobileHome.dart';
 import 'package:LoliSnatcher/ThemeItem.dart';
 import 'package:LoliSnatcher/widgets/ImageStats.dart';
 import 'package:LoliSnatcher/ImageWriter.dart';
+import 'package:LoliSnatcher/libBooru/Booru.dart';
+import 'package:LoliSnatcher/pages/settings/BooruEditPage.dart';
+import 'package:LoliSnatcher/utilities/Logger.dart';
+import 'package:LoliSnatcher/widgets/SettingsWidgets.dart';
 // import 'package:LoliSnatcher/widgets/FlashElements.dart';
 
 
@@ -34,6 +35,10 @@ void main() {
 
   if(Platform.isWindows || Platform.isLinux) {
     DartVLC.initialize();
+
+    // Init db stuff
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
   }
 
   runApp(MainApp());
@@ -179,7 +184,7 @@ class _MainAppState extends State<MainApp> {
           child: GetMaterialApp(
             title: 'LoliSnatcher',
             debugShowCheckedModeBanner: false, // hide debug banner in the corner
-            showPerformanceOverlay: settingsHandler.isDebug.value && settingsHandler.showFPS.value,
+            showPerformanceOverlay: settingsHandler.isDebug.value && settingsHandler.showPerf.value,
             scrollBehavior: CustomScrollBehavior(),
             theme: ThemeData(
               scaffoldBackgroundColor: (isDark && isAmoled) ? Colors.black : null,

--- a/lib/pages/LoliSyncPage.dart
+++ b/lib/pages/LoliSyncPage.dart
@@ -1,17 +1,23 @@
 import 'dart:core';
 import 'dart:io';
-import 'package:LoliSnatcher/widgets/FlashElements.dart';
-import 'package:LoliSnatcher/widgets/SettingsWidgets.dart';
-import 'package:flutter/cupertino.dart';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 
+import 'package:LoliSnatcher/SearchGlobals.dart';
 import 'package:LoliSnatcher/ServiceHandler.dart';
 import 'package:LoliSnatcher/SettingsHandler.dart';
-import 'package:LoliSnatcher/libBooru/LoliSync.dart';
 import 'package:LoliSnatcher/pages/LoliSyncSendPage.dart';
 import 'package:LoliSnatcher/pages/LoliSyncServerPage.dart';
+import 'package:LoliSnatcher/widgets/FlashElements.dart';
+import 'package:LoliSnatcher/widgets/SettingsWidgets.dart';
+
+enum SyncSide {
+  none,
+  receiver,
+  sender,
+}
 
 class LoliSyncPage extends StatefulWidget {
   LoliSyncPage();
@@ -20,31 +26,47 @@ class LoliSyncPage extends StatefulWidget {
 }
 class _LoliSyncPageState extends State<LoliSyncPage> {
   final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
-  final ipController = TextEditingController();
-  final portController = TextEditingController();
-  bool favourites = false, settings = false, booru = false;
-  final LoliSync loliSync = LoliSync();
+  final SearchHandler searchHandler = Get.find<SearchHandler>();
+
+  final TextEditingController ipController = TextEditingController();
+  final TextEditingController portController = TextEditingController();
+  final TextEditingController favouritesSkipController = TextEditingController();
+  final TextEditingController startPortController = TextEditingController();
+
+  SyncSide syncSide = SyncSide.none;
+
+  bool favourites = false, settings = false, booru = false, tabs = false;
+  String tabsMode = 'Merge';
+  List<String> tabsModesList = ['Merge', 'Replace'];
+  int? favCount;
+
   List<NetworkInterface> ipList = [];
   List<String> ipListNames = ['Auto', 'Localhost'];
   String selectedInterface = 'Auto';
   String? selectedAddress;
 
-  final startPortController = TextEditingController();
-  String startPort = '';
-
   Future<bool> _onWillPop() async {
     settingsHandler.lastSyncIp = ipController.text;
     settingsHandler.lastSyncPort = portController.text;
-    settingsHandler.saveSettings(restate: false);
-    return true;
+    bool result = await settingsHandler.saveSettings(restate: false);
+    return result;
   }
 
   @override
   void initState() {
     super.initState();
+
     ipController.text = settingsHandler.lastSyncIp;
     portController.text = settingsHandler.lastSyncPort;
+    favouritesSkipController.text = '';
+
+    getFavCount();
     getIPList();
+  }
+
+  void getFavCount() async {
+    favCount = await settingsHandler.dbHandler.getFavouritesCount();
+    setState(() { });
   }
 
   void getIPList() async {
@@ -52,6 +74,302 @@ class _LoliSyncPageState extends State<LoliSyncPage> {
     ipList.addAll(temp);
     ipListNames.addAll(temp.map((e) => e.name).toList());
     setState(() { });
+  }
+
+  Widget selectBuild() {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        SettingsButton(
+          name: 'Select what you want to do',
+          icon: Icon(Icons.help_center_outlined),
+          enabled: false,
+        ),
+        SettingsButton(
+          name: '',
+          enabled: false,
+        ),
+
+        SettingsButton(
+          name: 'SEND data TO another device',
+          icon: Icon(Icons.send_to_mobile),
+          action: () {
+            syncSide = SyncSide.sender;
+            setState(() { });
+          },
+        ),
+        SettingsButton(
+          name: 'RECEIVE data FROM another device',
+          icon: Icon(Icons.dns_outlined),
+          action: () {
+            syncSide = SyncSide.receiver;
+            setState(() { });
+          },
+        ),
+      ],
+    );
+  }
+
+  Widget senderBuild() {
+    return ListView(
+      children: <Widget>[
+        Container(
+          margin: EdgeInsets.fromLTRB(10, 10, 10, 10),
+          child: Text("Start the server on another device it will show an ip and port, fill those in and then hit start sync to send data from this device to the other"),
+        ),
+        SettingsTextInput(
+          controller: ipController,
+          title: 'IP Address',
+          hintText: "Host IP Address (i.e. 192.168.1.1)",
+          inputType: TextInputType.number,
+          inputFormatters: [FilteringTextInputFormatter.allow(RegExp('[0-9.]'))],
+          clearable: true,
+        ),
+        SettingsTextInput(
+          controller: portController,
+          title: 'Port',
+          hintText: "Host Port (i.e. 7777)",
+          inputType: TextInputType.number,
+          inputFormatters: <TextInputFormatter>[FilteringTextInputFormatter.digitsOnly],
+          clearable: true,
+        ),
+        SettingsToggle(
+          value: favourites,
+          onChanged: (newValue) {
+            setState(() {
+              favourites = newValue;
+            });
+          },
+          title: 'Send Favourites',
+          subtitle: Text('Favorites: ${favCount ?? '...'}'),
+          drawBottomBorder: favourites == true ? false : true,
+        ),
+
+        AnimatedSwitcher(
+          duration: Duration(milliseconds: 200),
+          child: favourites
+          ? SettingsTextInput(
+              controller: favouritesSkipController,
+              title: 'Start Favs Sync from #...',
+              hintText: "Start Favs Sync from #...",
+              inputType: TextInputType.number,
+              inputFormatters: <TextInputFormatter>[FilteringTextInputFormatter.digitsOnly],
+              clearable: true,
+              numberButtons: true,
+              numberStep: 100,
+              numberMin: 0,
+              numberMax: favCount?.toDouble() ?? double.infinity,
+              trailingIcon: IconButton(
+                icon: Icon(Icons.help_outline),
+                onPressed: () {
+                  showDialog(
+                    context: context,
+                    builder: (context) {
+                      return SettingsDialog(
+                        title: Text('Start Favs Sync from #...'),
+                        contentItems: <Widget>[
+                          Text('Allows to set from where the sync should start from'),
+                          Text('If you want to sync from the beginning leave this field blank'),
+                          Text(''),
+                          Text('Example: You have X amount of favs, set this field to 100, sync will start from item #100 and go until it reaches X'),
+                          Text('Order of favs: From oldest (0) to newest (X)')
+                        ],
+                      );
+                    }
+                  );
+                },
+              ),
+            )
+          : Container()
+        ),
+
+        SettingsToggle(
+          value: settings,
+          onChanged: (newValue) {
+            setState(() {
+              settings = newValue;
+            });
+          },
+          title: 'Send Settings',
+        ),
+        SettingsToggle(
+          value: booru,
+          onChanged: (newValue) {
+            setState(() {
+              booru = newValue;
+            });
+          },
+          title: 'Send Booru Configs',
+          subtitle: Text('Configs: ${settingsHandler.booruList.length}'),
+        ),
+        SettingsToggle(
+          value: tabs,
+          onChanged: (newValue) {
+            setState(() {
+              tabs = newValue;
+            });
+          },
+          title: 'Send Tabs',
+          subtitle: Text('Tabs: ${searchHandler.list.length}'),
+          drawBottomBorder: tabs == true ? false : true,
+        ),
+
+        AnimatedSwitcher(
+          duration: Duration(milliseconds: 200),
+          child: tabs
+          ? SettingsDropdown(
+              selected: tabsMode,
+              values: tabsModesList,
+              onChanged: (String? newValue) {
+                setState(() {
+                  tabsMode = newValue!;
+                });
+              },
+              title: 'Tabs Sync Mode',
+              trailingIcon: IconButton(
+                icon: Icon(Icons.help_outline),
+                onPressed: () {
+                  showDialog(
+                    context: context,
+                    builder: (context) {
+                      return SettingsDialog(
+                        title: Text('Tabs Sync Mode'),
+                        contentItems: <Widget>[
+                          Text('Merge: Merge the tabs from this device on the other device, tabs with unknown boorus and already existing tabs will be ignored'),
+                          Text(''),
+                          Text('Replace: Completely replace the tabs on the other device with the tabs from this device'),
+                        ],
+                      );
+                    }
+                  );
+                },
+              ),
+            )
+          : Container()
+        ),
+
+        SettingsButton(name: '', enabled: false),
+        SettingsButton(
+          name: 'Start Sync',
+          icon: Icon(Icons.send_to_mobile),
+          action: () {
+            bool isAddressEntered = ipController.text.isNotEmpty && portController.text.isNotEmpty;
+            bool isAnySyncSelected = favourites || settings || booru || tabs;
+            bool syncAllowed = isAddressEntered && isAnySyncSelected;
+
+            if(syncAllowed) {
+              var page = () => LoliSyncSendPage(
+                ip: ipController.text,
+                port: portController.text,
+                settings: settings,
+                favourites: favourites,
+                booru: booru,
+                tabs: tabs,
+                tabsMode: tabsMode,
+                favSkip: int.tryParse(favouritesSkipController.text) ?? 0,
+              );
+              SettingsPageOpen(context: context, page: page);
+            } else {
+              String errorString = '???';
+              if (!isAddressEntered) {
+                errorString = 'The Port and IP fields cannot be empty!';
+              } else if (!isAnySyncSelected) {
+                errorString = "You haven't selected anything to sync!";
+              }
+              FlashElements.showSnackbar(
+                context: context,
+                title: Text(
+                  "Error!",
+                  style: TextStyle(fontSize: 20)
+                ),
+                content: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(errorString),
+                  ],
+                ),
+                sideColor: Colors.red,
+                leadingIcon: Icons.error,
+                leadingIconColor: Colors.red,
+              );
+            }
+          },
+        ),
+      ],
+    );
+  }
+
+  Widget receiverBuild() {
+    return ListView(
+      children: <Widget>[
+        Container(
+          margin: EdgeInsets.fromLTRB(10, 10, 10, 10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text("Stats of this device:"),
+              Text("Favourites: ${favCount ?? '...'}"),
+              Text("Boorus: ${settingsHandler.booruList.length}"),
+              Text("Tabs: ${searchHandler.list.length}"),
+            ],
+          ),
+        ),
+        Container(
+          margin: EdgeInsets.fromLTRB(10, 10, 10, 10),
+          child: Text("Start the server if you want your device to recieve data from another, do not use this on public wifi as you might get pozzed"),
+        ),
+        SettingsDropdown(
+          selected: selectedInterface,
+          values: ipListNames,
+          onChanged: (String? newValue) {
+            selectedInterface = newValue!;
+            NetworkInterface? findInterface;
+            try {
+              findInterface = ipList.firstWhere((el) => el.name == newValue);
+            } catch (e) {
+              
+            }
+            if(newValue == 'Localhost') {
+              selectedAddress = '127.0.0.1';
+            } else {
+              selectedAddress = findInterface?.addresses[0].address;
+            }
+            setState(() { });
+          },
+          title: 'Available Network Interfaces'
+        ),
+        Container(
+          margin: EdgeInsets.fromLTRB(10, 10, 10, 10),
+          child: Text('Selected Interface IP: ${selectedAddress ?? 'none'}'),
+        ),
+        SettingsTextInput(
+          controller: startPortController,
+          title: 'Start Server at Port',
+          hintText: "Server Port (will default to '8080' if empty)",
+          inputType: TextInputType.number,
+          inputFormatters: <TextInputFormatter>[FilteringTextInputFormatter.digitsOnly],
+          clearable: true,
+        ),
+        SettingsButton(
+          name: 'Start Receiver Server',
+          icon: Icon(Icons.dns_outlined),
+          page: () => LoliSyncServerPage(selectedAddress, startPortController.text.isEmpty ? '8080' : startPortController.text),
+        ),
+      ],
+    );
+  }
+
+  Widget conditionalBuild() {
+    if(syncSide == SyncSide.none) {
+      return selectBuild();
+    } else if(syncSide == SyncSide.sender) {
+      return senderBuild();
+    } else if(syncSide == SyncSide.receiver) {
+      return receiverBuild();
+    } else {
+      // Should never happen but just in case
+      return const SizedBox();
+    }
   }
 
   @override
@@ -62,145 +380,8 @@ class _LoliSyncPageState extends State<LoliSyncPage> {
         resizeToAvoidBottomInset: true,
         appBar: AppBar(
           title: Text("LoliSync"),
-          leading: IconButton(
-              icon: Icon(Icons.arrow_back),
-              onPressed: () async {
-                Get.back();
-              }),
         ),
-        body: Center(
-          child: ListView(
-            children: <Widget>[
-              Container(
-                margin: EdgeInsets.fromLTRB(10, 10, 10, 10),
-                child: Text(
-                  "Start the server on another device it will show an ip and port, fill those in and then hit start sync to send data from this device to the other"),
-                ),
-              SettingsTextInput(
-                controller: ipController,
-                title: 'IP Address',
-                hintText: "Host IP Address (i.e. 192.168.1.1)",
-                inputType: TextInputType.number,
-                inputFormatters: [FilteringTextInputFormatter.allow(RegExp('[0-9.]'))],
-              ),
-              SettingsTextInput(
-                controller: portController,
-                title: 'Port',
-                hintText: "Host Port (i.e. 7777)",
-                inputType: TextInputType.number,
-                inputFormatters: <TextInputFormatter>[FilteringTextInputFormatter.digitsOnly],
-              ),
-              SettingsToggle(
-                value: favourites,
-                onChanged: (newValue) {
-                  setState(() {
-                    favourites = newValue;
-                  });
-                },
-                title: 'Send Favourites',
-              ),
-              SettingsToggle(
-                value: settings,
-                onChanged: (newValue) {
-                  setState(() {
-                    settings = newValue;
-                  });
-                },
-                title: 'Send Settings',
-              ),
-              SettingsToggle(
-                value: booru,
-                onChanged: (newValue) {
-                  setState(() {
-                    booru = newValue;
-                  });
-                },
-                title: 'Send Booru Configs',
-              ),
-
-              SettingsButton(name: '', enabled: false),
-              SettingsButton(
-                name: 'Start Sync',
-                icon: Icon(Icons.send_to_mobile),
-                action: () {
-                  bool isAddressEntered = ipController.text.isNotEmpty && portController.text.isNotEmpty;
-                  bool isAnySyncSelected = favourites || settings || booru;
-                  bool syncAllowed = isAddressEntered && isAnySyncSelected;
-
-                  if(syncAllowed) {
-                    var page = () => LoliSyncSendPage(ipController.text, portController.text, settings, favourites, booru);
-                    SettingsPageOpen(context: context, page: page);
-                  } else {
-                    String errorString = '???';
-                    if (!isAddressEntered) {
-                      errorString = 'The Port and IP fields cannot be empty!';
-                    } else if (!isAnySyncSelected) {
-                      errorString = "You haven't selected anything to sync!";
-                    }
-                    FlashElements.showSnackbar(
-                      context: context,
-                      title: Text(
-                        "Error!",
-                        style: TextStyle(fontSize: 20)
-                      ),
-                      content: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(errorString),
-                        ],
-                      ),
-                      sideColor: Colors.red,
-                      leadingIcon: Icons.error,
-                      leadingIconColor: Colors.red,
-                    );
-                  }
-                },
-              ),
-
-              SettingsButton(name: '', enabled: false),
-              Container(
-                margin: EdgeInsets.fromLTRB(10, 10, 10, 10),
-                child: Text("Start the server if you want your device to recieve data from another, do not use this on public wifi as you might get pozzed"),
-              ),
-              SettingsDropdown(
-                selected: selectedInterface,
-                values: ipListNames,
-                onChanged: (String? newValue) {
-                  selectedInterface = newValue!;
-                  NetworkInterface? findInterface;
-                  try {
-                     findInterface = ipList.firstWhere((el) => el.name == newValue);
-                  } catch (e) {
-                    
-                  }
-                  if(newValue == 'Localhost') {
-                    selectedAddress = '127.0.0.1';
-                  } else {
-                    selectedAddress = findInterface?.addresses[0].address;
-                  }
-                  setState(() { });
-                },
-                title: 'Available Network Interfaces'
-              ),
-              Container(
-                margin: EdgeInsets.fromLTRB(10, 10, 10, 10),
-                child: Text('Selected Interface IP: ${selectedAddress ?? 'none'}'),
-              ),
-              SettingsTextInput(
-                controller: startPortController,
-                title: 'Start Server at Port',
-                hintText: "Server Port (will default to '1234' if empty)",
-                inputType: TextInputType.number,
-                inputFormatters: <TextInputFormatter>[FilteringTextInputFormatter.digitsOnly],
-              ),
-              SettingsButton(
-                name: 'Start Receiver Server',
-                icon: Icon(Icons.dns_outlined),
-                page: () => LoliSyncServerPage(selectedAddress, startPortController.text.isEmpty ? '1234' : startPortController.text),
-              ),
-            ],
-          ),
-        ),
+        body: Center(child: conditionalBuild()),
       ),
     );
   }

--- a/lib/pages/LoliSyncServerPage.dart
+++ b/lib/pages/LoliSyncServerPage.dart
@@ -13,6 +13,20 @@ class LoliSyncServerPage extends StatelessWidget {
   final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
   final LoliSync loliSync = LoliSync();
 
+  List<String> messagesHistory = [];
+  int maxHistoryLength = 10;
+
+  void addMessage(String message) {
+    // add new message to history but limit it to 10 items
+    if(message.startsWith('Server active at') && messagesHistory.indexWhere((msg) => msg.startsWith('Server active at')) != -1) {
+      return;
+    }
+    messagesHistory.insert(0, message);
+    if (messagesHistory.length > maxHistoryLength) {
+      messagesHistory.removeLast();
+    }
+  }
+
   Future<bool> _onWillPop(BuildContext context) async {
     final shouldPop = await showDialog(
       context: context,
@@ -51,8 +65,8 @@ class LoliSyncServerPage extends StatelessWidget {
           title: Text("LoliSync"),
           leading: IconButton(
               icon: Icon(Icons.arrow_back),
-              onPressed: () async{
-                if (await _onWillPop(context)){
+              onPressed: () async {
+                if (await _onWillPop(context)) {
                   Get.back();
                 }
               }
@@ -60,11 +74,11 @@ class LoliSyncServerPage extends StatelessWidget {
         ),
         body:Center(
             child: StreamBuilder<String>(
-              stream: loliSync.startServer(settingsHandler, selectedIP, customPort),
+              stream: loliSync.startServer(selectedIP, customPort),
               builder: (BuildContext context, AsyncSnapshot<String> snapshot) {
                 String status = "";
                 if (snapshot.hasError) {
-                  status = "Error";
+                  status = "Error ${snapshot.error}";
                 } else {
                   switch (snapshot.connectionState) {
                     case ConnectionState.none:
@@ -74,6 +88,7 @@ class LoliSyncServerPage extends StatelessWidget {
                     case ConnectionState.active:
                     case ConnectionState.done:
                       status = "${snapshot.data}";
+                      addMessage(status);
                       break;
                   }
                 }
@@ -81,9 +96,29 @@ class LoliSyncServerPage extends StatelessWidget {
                   child: Column(
                     children: [
                       const SizedBox(height: 10),
-                      Icon(Icons.electrical_services, size: 250),
+                      Icon(Icons.dns_outlined, size: 250),
                       const SizedBox(height: 10),
-                      Text(status,style: TextStyle(fontSize: 18)),
+                      Padding(
+                        padding: const EdgeInsets.all(4.0),
+                        child: Text(status, style: TextStyle(fontSize: 18)),
+                      ),
+                      // show history of messages with last items fading away in color
+                      if(messagesHistory.length > 1)
+                        Expanded(
+                          child: ListView.builder(
+                            itemCount: messagesHistory.length - 1,
+                            itemBuilder: (BuildContext context, int index) {
+                              final int indexWoutStart = index + 1;
+                              return Opacity(
+                                opacity: 1 - (indexWoutStart / maxHistoryLength),
+                                child: Padding(
+                                  padding: const EdgeInsets.all(4.0),
+                                  child: Center(child: Text(messagesHistory[indexWoutStart], style: TextStyle(fontSize: 18))),
+                                ),
+                              );
+                            },
+                          ),
+                        ),
                     ],
                   ),
                 );

--- a/lib/pages/SettingsPage.dart
+++ b/lib/pages/SettingsPage.dart
@@ -44,8 +44,10 @@ class SettingsPage extends StatelessWidget {
           title: Text("Settings"),
           leading: IconButton(
               icon: Icon(Icons.arrow_back),
-              onPressed: () async{
-                Get.back();
+              onPressed: () async {
+                if (await _onWillPop()) {
+                  Get.back();
+                }
               }
           ),
         ),

--- a/lib/pages/SnatcherPage.dart
+++ b/lib/pages/SnatcherPage.dart
@@ -38,6 +38,7 @@ class _SnatcherPageState extends State<SnatcherPage> {
     getPerms();
     //If the user has searched tags on the main window they will be loaded into the tags field
     snatcherTagsController.text = searchHandler.currentTab.tags;
+    snatcherAmountController.text = 10.toString();
     selectedBooru = searchHandler.currentTab.selectedBooru.value;
     snatcherSleepController.text = settingsHandler.snatchCooldown.toString();
   }
@@ -57,6 +58,7 @@ class _SnatcherPageState extends State<SnatcherPage> {
               title: 'Tags',
               hintText: "Enter Tags",
               inputType: TextInputType.text,
+              clearable: true,
             ),
             SettingsTextInput(
               controller: snatcherAmountController,
@@ -66,6 +68,11 @@ class _SnatcherPageState extends State<SnatcherPage> {
               inputFormatters: <TextInputFormatter>[
                 FilteringTextInputFormatter.digitsOnly
               ],
+              resetText: () => 10.toString(),
+              numberButtons: true,
+              numberStep: 10,
+              numberMin: 10,
+              numberMax: double.infinity,
             ),
             SettingsTextInput(
               controller: snatcherSleepController,
@@ -75,6 +82,11 @@ class _SnatcherPageState extends State<SnatcherPage> {
               inputFormatters: <TextInputFormatter>[
                 FilteringTextInputFormatter.digitsOnly
               ],
+              resetText: () => settingsHandler.snatchCooldown.toString(),
+              numberButtons: true,
+              numberStep: 50,
+              numberMin: 100,
+              numberMax: double.infinity,
             ),
             SettingsBooruDropdown(
               selected: selectedBooru,

--- a/lib/pages/settings/BackupRestorePage.dart
+++ b/lib/pages/settings/BackupRestorePage.dart
@@ -2,17 +2,16 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:path_provider/path_provider.dart';
+
+import 'package:LoliSnatcher/SettingsHandler.dart';
+import 'package:LoliSnatcher/ServiceHandler.dart';
 import 'package:LoliSnatcher/libBooru/Booru.dart';
 import 'package:LoliSnatcher/libBooru/DBHandler.dart';
 import 'package:LoliSnatcher/widgets/FlashElements.dart';
 import 'package:LoliSnatcher/widgets/SettingsWidgets.dart';
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
-import 'package:get/get.dart';
-
-import 'package:LoliSnatcher/SettingsHandler.dart';
-import 'package:LoliSnatcher/ServiceHandler.dart';
-import 'package:path_provider/path_provider.dart';
 
 class BackupRestorePage extends StatefulWidget {
   BackupRestorePage();
@@ -48,7 +47,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
 
   //called when page is closed, sets settingshandler variables and then writes settings to disk
   Future<bool> _onWillPop() async {
-    bool result = await settingsHandler.saveSettings(restate: true);
+    bool result = await settingsHandler.saveSettings(restate: false);
     return result;
   }
 
@@ -100,17 +99,21 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
               SettingsButton(
                 name: 'Backup Settings',
                 action: () async {
-                  File file = File(await serviceHandler.getConfigDir() + 'settings.json');
-                  Directory? dlDir = (await getExternalStorageDirectories())?.first;
-                  if(dlDir != null) {
-                    File newFile = File(dlDir.path + '/settings.json');
-                    if(!(await newFile.exists())) {
-                      await newFile.create();
+                  try {
+                    File file = File(await serviceHandler.getConfigDir() + 'settings.json');
+                    Directory? dlDir = (await getExternalStorageDirectories())?.first;
+                    if(dlDir != null) {
+                      File newFile = File(dlDir.path + '/settings.json');
+                      if(!(await newFile.exists())) {
+                        await newFile.create();
+                      }
+                      newFile.writeAsBytes(await file.readAsBytes());
+                      showSnackbar(context, 'Settings saved to settings.json', false);
+                    } else {
+                      showSnackbar(context, 'No Access to backup folder!', true);
                     }
-                    newFile.writeAsBytes(await file.readAsBytes());
-                    showSnackbar(context, 'Settings saved to settings.json', false);
-                  } else {
-                    showSnackbar(context, 'No Access to backup folder!', true);
+                  } catch (e) {
+                    showSnackbar(context, 'Error while saving settings! $e', true);
                   }
                 },
                 drawTopBorder: true,
@@ -119,22 +122,26 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
                 name: 'Restore Settings',
                 subtitle: Text('settings.json'),
                 action: () async {
-                  Directory? dlDir = (await getExternalStorageDirectories())?.first;
-                  if(dlDir != null) {
-                    File file = File(dlDir.path + '/settings.json');
-                    if (await file.exists()) {
-                      File newFile = File(await serviceHandler.getConfigDir() + 'settings.json');
-                      if (!(await newFile.exists())) {
-                        await newFile.create();
+                  try {
+                    Directory? dlDir = (await getExternalStorageDirectories())?.first;
+                    if(dlDir != null) {
+                      File file = File(dlDir.path + '/settings.json');
+                      if (await file.exists()) {
+                        File newFile = File(await serviceHandler.getConfigDir() + 'settings.json');
+                        if (!(await newFile.exists())) {
+                          await newFile.create();
+                        }
+                        newFile.writeAsBytes(await file.readAsBytes());
+                        settingsHandler.loadSettingsJson();
+                        showSnackbar(context, 'Settings restored from backup!', false);
+                      } else {
+                        showSnackbar(context, 'No Restore File Found!', true);
                       }
-                      newFile.writeAsBytes(await file.readAsBytes());
-                      settingsHandler.loadSettingsJson();
-                      showSnackbar(context, 'Settings restored from backup!', false);
                     } else {
-                      showSnackbar(context, 'No Restore File Found!', true);
+                      showSnackbar(context, 'No Access to backup folder!', true);
                     }
-                  } else {
-                    showSnackbar(context, 'No Access to backup folder!', true);
+                  } catch (e) {
+                    showSnackbar(context, 'Error while restoring settings! $e', true);
                   }
                 },
               ),
@@ -144,17 +151,21 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
               SettingsButton(
                 name: 'Backup Database',
                 action: () async {
-                  File file = File(await serviceHandler.getConfigDir() + 'store.db');
-                  Directory? dlDir = (await getExternalStorageDirectories())?.first;
-                  if(dlDir != null) {
-                    File newFile = File(dlDir.path + '/store.db');
-                    if(!(await newFile.exists())) {
-                      await newFile.create();
+                  try {
+                    File file = File(await serviceHandler.getConfigDir() + 'store.db');
+                    Directory? dlDir = (await getExternalStorageDirectories())?.first;
+                    if(dlDir != null) {
+                      File newFile = File(dlDir.path + '/store.db');
+                      if(!(await newFile.exists())) {
+                        await newFile.create();
+                      }
+                      newFile.writeAsBytes(await file.readAsBytes());
+                      showSnackbar(context, 'Database saved to store.db', false);
+                    } else {
+                      showSnackbar(context, 'No Access to backup folder!', true);
                     }
-                    newFile.writeAsBytes(await file.readAsBytes());
-                    showSnackbar(context, 'Database saved to store.db', false);
-                  } else {
-                    showSnackbar(context, 'No Access to backup folder!', true);
+                  } catch (e) {
+                    showSnackbar(context, 'Error while saving database! $e', true);
                   }
                 },
               ),
@@ -162,23 +173,27 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
                 name: 'Restore Database',
                 subtitle: Text('store.db'),
                 action: () async {
-                  Directory? dlDir = (await getExternalStorageDirectories())?.first;
-                  if(dlDir != null) {
-                    File file = File(dlDir.path + '/store.db');
-                    if (await file.exists()) {
-                      File newFile = File(await serviceHandler.getConfigDir() + 'store.db');
-                      if (!(await newFile.exists())) {
-                        await newFile.create();
+                  try {
+                    Directory? dlDir = (await getExternalStorageDirectories())?.first;
+                    if(dlDir != null) {
+                      File file = File(dlDir.path + '/store.db');
+                      if (await file.exists()) {
+                        File newFile = File(await serviceHandler.getConfigDir() + 'store.db');
+                        if (!(await newFile.exists())) {
+                          await newFile.create();
+                        }
+                        await newFile.writeAsBytes(await file.readAsBytes());
+                        settingsHandler.dbHandler = DBHandler();
+                        await settingsHandler.dbHandler.dbConnect(newFile.path);
+                        showSnackbar(context, 'Database restored from backup!', false);
+                      } else {
+                        showSnackbar(context, 'No Restore File Found!', true);
                       }
-                      await newFile.writeAsBytes(await file.readAsBytes());
-                      settingsHandler.dbHandler = DBHandler();
-                      await settingsHandler.dbHandler.dbConnect(newFile.path);
-                      showSnackbar(context, 'Database restored from backup!', false);
                     } else {
-                      showSnackbar(context, 'No Restore File Found!', true);
+                      showSnackbar(context, 'No Access to backup folder!', true);
                     }
-                  } else {
-                    showSnackbar(context, 'No Access to backup folder!', true);
+                  } catch (e) {
+                    showSnackbar(context, 'Error while restoring database! $e', true);
                   }
                 },
               ),
@@ -188,29 +203,33 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
               SettingsButton(
                 name: 'Backup Boorus',
                 action: () async {
-                  Directory? dlDir = (await getExternalStorageDirectories())?.first;
-                  if(dlDir != null) {
-                    String configBoorusPath = await serviceHandler.getConfigDir() + 'boorus/';
-                    Directory configBoorusDir = Directory(configBoorusPath);
-                    if(await configBoorusDir.exists()) {
-                      String restoreBoorusPath = dlDir.path + '/boorus/';
-                      Directory restoreBoorusDir = await Directory(restoreBoorusPath).create(recursive:true);
-                      List files = configBoorusDir.listSync();
-                      if (files.length > 0) {
-                        for (int i = 0; i < files.length; i++) {
-                          if (files[i].path.contains(".json")) {
-                            Booru booruFromFile = Booru.fromJSON(files[i].readAsStringSync());
-                            File booruFile = File(restoreBoorusPath + "${booruFromFile.name}.json");
-                            var writer = booruFile.openWrite();
-                            writer.write(jsonEncode(booruFromFile.toJSON()));
-                            writer.close();
+                  try {
+                    Directory? dlDir = (await getExternalStorageDirectories())?.first;
+                    if(dlDir != null) {
+                      String configBoorusPath = await serviceHandler.getConfigDir() + 'boorus/';
+                      Directory configBoorusDir = Directory(configBoorusPath);
+                      if(await configBoorusDir.exists()) {
+                        String restoreBoorusPath = dlDir.path + '/boorus/';
+                        Directory restoreBoorusDir = await Directory(restoreBoorusPath).create(recursive:true);
+                        List files = configBoorusDir.listSync();
+                        if (files.length > 0) {
+                          for (int i = 0; i < files.length; i++) {
+                            if (files[i].path.contains(".json")) {
+                              Booru booruFromFile = Booru.fromJSON(files[i].readAsStringSync());
+                              File booruFile = File(restoreBoorusPath + "${booruFromFile.name}.json");
+                              var writer = booruFile.openWrite();
+                              writer.write(jsonEncode(booruFromFile.toJSON()));
+                              writer.close();
+                            }
                           }
+                          showSnackbar(context, 'Boorus saved in /boorus folder', false);
                         }
-                        showSnackbar(context, 'Boorus saved in /boorus folder', false);
                       }
+                    } else {
+                      showSnackbar(context, 'No Access to backup folder!', true);
                     }
-                  } else {
-                    showSnackbar(context, 'No Access to backup folder!', true);
+                  } catch (e) {
+                    showSnackbar(context, 'Error while saving boorus! $e', true);
                   }
                 },
               ),
@@ -218,33 +237,37 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
                 name: 'Restore Boorus',
                 subtitle: Text('/boorus/[Booru Name].json'),
                 action: () async {
-                  Directory? dlDir = (await getExternalStorageDirectories())?.first;
-                  if(dlDir != null) {
-                    String restoreBoorusPath = dlDir.path + '/boorus/';
-                    Directory restoreBoorusDir = Directory(restoreBoorusPath);
-                    if(await restoreBoorusDir.exists()) {
-                      String configBoorusPath = await serviceHandler.getConfigDir() + 'boorus/';
-                      Directory configBoorusDir = await Directory(configBoorusPath).create(recursive:true);
-                      List files = restoreBoorusDir.listSync();
-                      if (files.length > 0) {
-                        for (int i = 0; i < files.length; i++) {
-                          if (files[i].path.contains(".json")) {
-                            Booru booruFromFile = Booru.fromJSON(files[i].readAsStringSync());
-                            bool alreadyExists = settingsHandler.booruList.indexWhere((el) => el.baseURL == booruFromFile.baseURL && el.name == booruFromFile.name) != -1;
-                            if(!alreadyExists) {
-                              File booruFile = File(configBoorusDir.path + "${booruFromFile.name}.json");
-                              var writer = booruFile.openWrite();
-                              writer.write(jsonEncode(booruFromFile.toJSON()));
-                              writer.close();
+                  try {
+                    Directory? dlDir = (await getExternalStorageDirectories())?.first;
+                    if(dlDir != null) {
+                      String restoreBoorusPath = dlDir.path + '/boorus/';
+                      Directory restoreBoorusDir = Directory(restoreBoorusPath);
+                      if(await restoreBoorusDir.exists()) {
+                        String configBoorusPath = await serviceHandler.getConfigDir() + 'boorus/';
+                        Directory configBoorusDir = await Directory(configBoorusPath).create(recursive:true);
+                        List files = restoreBoorusDir.listSync();
+                        if (files.length > 0) {
+                          for (int i = 0; i < files.length; i++) {
+                            if (files[i].path.contains(".json")) {
+                              Booru booruFromFile = Booru.fromJSON(files[i].readAsStringSync());
+                              bool alreadyExists = settingsHandler.booruList.indexWhere((el) => el.baseURL == booruFromFile.baseURL && el.name == booruFromFile.name) != -1;
+                              if(!alreadyExists) {
+                                File booruFile = File(configBoorusDir.path + "${booruFromFile.name}.json");
+                                var writer = booruFile.openWrite();
+                                writer.write(jsonEncode(booruFromFile.toJSON()));
+                                writer.close();
+                              }
                             }
                           }
+                          settingsHandler.loadBoorus();
+                          showSnackbar(context, 'Boorus restored from backup!', false);
                         }
-                        settingsHandler.loadBoorus();
-                        showSnackbar(context, 'Boorus restored from backup!', false);
                       }
+                    } else {
+                      showSnackbar(context, 'No Access to backup folder!', true);
                     }
-                  } else {
-                    showSnackbar(context, 'No Access to backup folder!', true);
+                  } catch (e) {
+                    showSnackbar(context, 'Error while restoring boorus! $e', true);
                   }
                 },
               ),

--- a/lib/pages/settings/BooruEditPage.dart
+++ b/lib/pages/settings/BooruEditPage.dart
@@ -86,12 +86,14 @@ class _BooruEditState extends State<BooruEdit> {
               title: 'Name',
               hintText: "Enter Booru Name",
               inputType: TextInputType.text,
+              clearable: true,
             ),
             SettingsTextInput(
               controller: booruURLController,
               title: 'URL',
               hintText: "Enter Booru URL",
               inputType: TextInputType.url,
+              clearable: true,
             ),
             SettingsDropdown(
               selected: selectedBooruType,
@@ -108,12 +110,14 @@ class _BooruEditState extends State<BooruEdit> {
               title: 'Favicon',
               hintText: "(Autofills if blank)",
               inputType: TextInputType.url,
+              clearable: true,
             ),
             SettingsTextInput(
               controller: booruDefTagsController,
               title: 'Default Tags',
               hintText: "Default search for booru",
               inputType: TextInputType.text,
+              clearable: true,
             ),
 
             Container(
@@ -213,12 +217,14 @@ class _BooruEditState extends State<BooruEdit> {
               title: getUserIDTitle(),
               hintText: "(Can be blank)",
               inputType: TextInputType.text,
+              clearable: true,
             ),
             SettingsTextInput(
               controller: booruAPIKeyController,
               title: getApiKeyTitle(),
               hintText: "(Can be blank)",
               inputType: TextInputType.text,
+              clearable: true,
             ),
             
           ],

--- a/lib/pages/settings/BooruPage.dart
+++ b/lib/pages/settings/BooruPage.dart
@@ -79,7 +79,7 @@ class _BooruPageState extends State<BooruPage> {
       settingsHandler.prefBooru = selectedBooru?.name ?? '';
     }
     settingsHandler.limit = int.parse(limitController.text);
-    bool result = await settingsHandler.saveSettings(restate: true);
+    bool result = await settingsHandler.saveSettings(restate: false);
     settingsHandler.sortBooruList();
     return result;
   }
@@ -101,6 +101,8 @@ class _BooruPageState extends State<BooruPage> {
                   title: 'Default Tags',
                   hintText: "Tags searched when app opens",
                   inputType: TextInputType.text,
+                  clearable: true,
+                  resetText: () => 'rating:safe',
                 ),
                 SettingsTextInput(
                   controller: limitController,
@@ -110,6 +112,11 @@ class _BooruPageState extends State<BooruPage> {
                   inputFormatters: <TextInputFormatter>[
                     FilteringTextInputFormatter.digitsOnly
                   ],
+                  resetText: () => settingsHandler.map['limit']?['default']?.toString() ?? '10',
+                  numberButtons: true,
+                  numberStep: 10,
+                  numberMin: 10,
+                  numberMax: 100,
                   validator: (String? value) {
                     int? parse = int.tryParse(value ?? '');
                     if(value == null || value.isEmpty) {
@@ -136,7 +143,7 @@ class _BooruPageState extends State<BooruPage> {
                   },
                   title: 'Booru',
                   trailingIcon: IconButton(
-                    icon: Icon(Icons.info, color: Get.theme.colorScheme.secondary),
+                    icon: Icon(Icons.help_outline),
                     onPressed: () {
                       showDialog(
                         context: context,

--- a/lib/pages/settings/DatabasePage.dart
+++ b/lib/pages/settings/DatabasePage.dart
@@ -5,7 +5,6 @@ import 'package:LoliSnatcher/libBooru/BooruItem.dart';
 import 'package:LoliSnatcher/libBooru/SankakuHandler.dart';
 import 'package:LoliSnatcher/widgets/FlashElements.dart';
 import 'package:LoliSnatcher/widgets/SettingsWidgets.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
@@ -38,7 +37,7 @@ class _DatabasePageState extends State<DatabasePage> {
     // Set settingshandler values here
     settingsHandler.dbEnabled = dbEnabled;
     settingsHandler.searchHistoryEnabled = searchHistoryEnabled;
-    bool result = await settingsHandler.saveSettings(restate: true);
+    bool result = await settingsHandler.saveSettings(restate: false);
     return result;
   }
 
@@ -72,12 +71,14 @@ class _DatabasePageState extends State<DatabasePage> {
       leadingIconColor: Colors.green,
       sideColor: Colors.green,
     );
+
     setState(() {
       updatingItems = [];
       updatingFailed = 0;
       updatingDone = 0;
       isUpdating = true;
     });
+
     updatingItems = await settingsHandler.dbHandler.getSankakuItems();
     Booru? sankakuBooru = getSankakuBooru();
     if(sankakuBooru == null) {
@@ -90,6 +91,7 @@ class _DatabasePageState extends State<DatabasePage> {
         leadingIconColor: Colors.red,
         sideColor: Colors.red,
       );
+
       setState(() {
         updatingFailed = 0;
         updatingDone = 0;
@@ -98,11 +100,11 @@ class _DatabasePageState extends State<DatabasePage> {
       return true;
     }
 
-    SankakuHandler sankakuHandler = new SankakuHandler(sankakuBooru, 10);
+    SankakuHandler sankakuHandler = SankakuHandler(sankakuBooru, 10);
     for(BooruItem item in updatingItems) {
       if(isUpdating) {
         await Future.delayed(Duration(milliseconds: 100));
-        List result = await sankakuHandler.updateFavourite(item);
+        List result = await sankakuHandler.updateItem(item);
         if (result[1] == false) {
           setState(() {
             updatingFailed += 1;
@@ -166,7 +168,7 @@ class _DatabasePageState extends State<DatabasePage> {
                 },
                 title: 'Enable Database',
                 trailingIcon: IconButton(
-                  icon: Icon(Icons.info, color: Get.theme.colorScheme.secondary),
+                  icon: Icon(Icons.help_outline),
                   onPressed: () {
                     Get.dialog(
                       SettingsDialog(
@@ -189,7 +191,7 @@ class _DatabasePageState extends State<DatabasePage> {
                 },
                 title: 'Enable Search History',
                 trailingIcon: IconButton(
-                  icon: Icon(Icons.info, color: Get.theme.colorScheme.secondary),
+                  icon: Icon(Icons.help_outline),
                   onPressed: () {
                     Get.dialog(
                       SettingsDialog(

--- a/lib/pages/settings/DebugPage.dart
+++ b/lib/pages/settings/DebugPage.dart
@@ -36,7 +36,7 @@ class _DebugPageState extends State<DebugPage> {
   //called when page is closed, sets settingshandler variables and then writes settings to disk
   Future<bool> _onWillPop() async {
     settingsHandler.allowSelfSignedCerts = allowSelfSignedCerts;
-    bool result = await settingsHandler.saveSettings(restate: true);
+    bool result = await settingsHandler.saveSettings(restate: false);
     if (allowSelfSignedCerts){
       HttpOverrides.global = MyHttpOverrides();
     } else {
@@ -58,13 +58,22 @@ class _DebugPageState extends State<DebugPage> {
           child: ListView(
             children: [
               SettingsToggle(
+                value: settingsHandler.showPerf.value,
+                onChanged: (newValue) {
+                  setState(() {
+                    settingsHandler.showPerf.value = newValue;
+                  });
+                },
+                title: 'Show Performance graph'
+              ),
+              SettingsToggle(
                 value: settingsHandler.showFPS.value,
                 onChanged: (newValue) {
                   setState(() {
                     settingsHandler.showFPS.value = newValue;
                   });
                 },
-                title: 'Show FPS Info'
+                title: 'Show FPS graph'
               ),
               SettingsToggle(
                 value: settingsHandler.showImageStats.value,
@@ -131,7 +140,7 @@ class _DebugPageState extends State<DebugPage> {
                 name: 'Animation speed ($timeDilation)',
                 icon: Icon(Icons.timelapse),
                 action: () {
-                  const List<double> speeds = [0.25, 0.5, 0.75, 1, 2, 3, 4];
+                  const List<double> speeds = [0.25, 0.5, 0.75, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20];
                   int currentIndex = speeds.indexOf(timeDilation);
                   int newIndex = 0;
                   if((currentIndex + 1) <= (speeds.length - 1)) {

--- a/lib/pages/settings/FilterTagsPage.dart
+++ b/lib/pages/settings/FilterTagsPage.dart
@@ -50,7 +50,7 @@ class _FiltersEditState extends State<FiltersEdit> with SingleTickerProviderStat
     settingsHandler.hatedTags = settingsHandler.cleanTagsList(hatedList);
     settingsHandler.lovedTags = settingsHandler.cleanTagsList(lovedList);
     settingsHandler.filterHated = filterHated;
-    bool result = await settingsHandler.saveSettings(restate: true);
+    bool result = await settingsHandler.saveSettings(restate: false);
     return result;
   }
 
@@ -239,6 +239,8 @@ class _FiltersEditState extends State<FiltersEdit> with SingleTickerProviderStat
                 controller: newTagController,
                 autofocus: isAddButton ? true : false,
                 inputType: TextInputType.text,
+                clearable: true,
+                resetText: isAddButton ? null : () => tag,
                 onSubmitted: (String text) {
                   if(text.trim() != '') {
                     isAddButton

--- a/lib/pages/settings/GalleryPage.dart
+++ b/lib/pages/settings/GalleryPage.dart
@@ -1,11 +1,10 @@
-import 'package:LoliSnatcher/widgets/FlashElements.dart';
-import 'package:LoliSnatcher/widgets/SettingsWidgets.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 
-import '../../SettingsHandler.dart';
+import 'package:LoliSnatcher/SettingsHandler.dart';
+import 'package:LoliSnatcher/widgets/FlashElements.dart';
+import 'package:LoliSnatcher/widgets/SettingsWidgets.dart';
 
 class GalleryPage extends StatefulWidget {
   GalleryPage();
@@ -16,7 +15,7 @@ class GalleryPage extends StatefulWidget {
 class _GalleryPageState extends State<GalleryPage> {
   final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
   bool autoHideImageBar = false, autoPlay = true, loadingGif = false, useVolumeButtonsForScroll = false, shitDevice = false, disableVideo = false;
-  late String galleryMode, galleryBarPosition, galleryScrollDirection, shareAction, zoomButtonPosition;
+  late String galleryMode, galleryBarPosition, galleryScrollDirection, shareAction, zoomButtonPosition, changePageButtonsPosition;
   List<List<String>>? buttonOrder;
   TextEditingController preloadController = TextEditingController();
   TextEditingController scrollSpeedController = TextEditingController();
@@ -31,6 +30,7 @@ class _GalleryPageState extends State<GalleryPage> {
     galleryScrollDirection = settingsHandler.galleryScrollDirection;
     shareAction = settingsHandler.shareAction;
     zoomButtonPosition = settingsHandler.zoomButtonPosition;
+    changePageButtonsPosition = settingsHandler.changePageButtonsPosition;
     autoPlay = settingsHandler.autoPlayEnabled;
     useVolumeButtonsForScroll = settingsHandler.useVolumeButtonsForScroll;
     scrollSpeedController.text = settingsHandler.volumeButtonsScrollSpeed.toString();
@@ -51,6 +51,7 @@ class _GalleryPageState extends State<GalleryPage> {
     settingsHandler.galleryScrollDirection = galleryScrollDirection;
     settingsHandler.shareAction = shareAction;
     settingsHandler.zoomButtonPosition = zoomButtonPosition;
+    settingsHandler.changePageButtonsPosition = changePageButtonsPosition;
     settingsHandler.autoPlayEnabled = autoPlay;
     settingsHandler.loadingGif = loadingGif;
     settingsHandler.shitDevice = shitDevice;
@@ -69,7 +70,7 @@ class _GalleryPageState extends State<GalleryPage> {
     }
     settingsHandler.preloadCount = int.parse(preloadController.text);
     // Set settingshandler values here
-    bool result = await settingsHandler.saveSettings(restate: true);
+    bool result = await settingsHandler.saveSettings(restate: false);
     return result;
   }
 
@@ -97,6 +98,11 @@ class _GalleryPageState extends State<GalleryPage> {
                 inputFormatters: <TextInputFormatter>[
                   FilteringTextInputFormatter.digitsOnly
                 ],
+                resetText: () => settingsHandler.map['preloadCount']?['default']?.toString() ?? "1",
+                numberButtons: true,
+                numberStep: 1,
+                numberMin: 0,
+                numberMax: 5,
                 validator: (String? value) {
                   int? parse = int.tryParse(value ?? '');
                   if(value == null || value.isEmpty) {
@@ -120,7 +126,7 @@ class _GalleryPageState extends State<GalleryPage> {
                 },
                 title: 'Gallery Quality',
                 trailingIcon: IconButton(
-                  icon: Icon(Icons.info, color: Get.theme.colorScheme.secondary),
+                  icon: Icon(Icons.help_outline),
                   onPressed: () {
                     showDialog(
                       context: context,
@@ -159,7 +165,7 @@ class _GalleryPageState extends State<GalleryPage> {
                 },
                 title: 'Default Share Action',
                 trailingIcon: IconButton(
-                  icon: Icon(Icons.info, color: Get.theme.colorScheme.secondary),
+                  icon: Icon(Icons.help_outline),
                   onPressed: () {
                     showDialog(
                       context: context,
@@ -203,6 +209,16 @@ class _GalleryPageState extends State<GalleryPage> {
                 },
                 title: 'Zoom Button Position',
               ),
+              SettingsDropdown(
+                selected: changePageButtonsPosition,
+                values: settingsHandler.map['changePageButtonsPosition']?['options'],
+                onChanged: (String? newValue){
+                  setState((){
+                    changePageButtonsPosition = newValue ?? settingsHandler.map['changePageButtonsPosition']?['default'];
+                  });
+                },
+                title: 'Change Page Buttons Position',
+              ),
               SettingsToggle(
                 value: autoHideImageBar,
                 onChanged: (newValue) {
@@ -223,7 +239,7 @@ class _GalleryPageState extends State<GalleryPage> {
                           name: 'Toolbar Buttons Order',
                           drawBottomBorder: false,
                           trailingIcon: IconButton(
-                            icon: Icon(Icons.info, color: Get.theme.colorScheme.secondary),
+                            icon: Icon(Icons.help_outline),
                             onPressed: () {
                               showDialog(
                                 context: context,
@@ -291,7 +307,7 @@ class _GalleryPageState extends State<GalleryPage> {
                 title: 'Disable Video',
                 drawTopBorder: true, // instead of border in reorder list
                 trailingIcon: IconButton(
-                  icon: Icon(Icons.info, color: Get.theme.colorScheme.secondary),
+                  icon: Icon(Icons.help_outline),
                   onPressed: () {
                     showDialog(
                       context: context,
@@ -345,7 +361,7 @@ class _GalleryPageState extends State<GalleryPage> {
                 },
                 title: 'Low Performance Mode',
                 trailingIcon: IconButton(
-                  icon: Icon(Icons.info, color: Get.theme.colorScheme.secondary),
+                  icon: Icon(Icons.help_outline),
                   onPressed: () {
                     showDialog(
                       context: context,
@@ -379,7 +395,7 @@ class _GalleryPageState extends State<GalleryPage> {
                 },
                 title: 'Use Volume Buttons for Scrolling',
                 trailingIcon: IconButton(
-                  icon: Icon(Icons.info, color: Get.theme.colorScheme.secondary),
+                  icon: Icon(Icons.help_outline),
                   onPressed: () {
                     showDialog(
                       context: context,
@@ -410,6 +426,11 @@ class _GalleryPageState extends State<GalleryPage> {
                 inputFormatters: <TextInputFormatter>[
                   FilteringTextInputFormatter.digitsOnly
                 ],
+                resetText: () => settingsHandler.map['volumeButtonsScrollSpeed']?['default']?.toString() ?? "200",
+                numberButtons: true,
+                numberStep: 100,
+                numberMin: 100,
+                numberMax: double.infinity,
                 validator: (String? value) {
                   int? parse = int.tryParse(value ?? '');
                   if(value == null || value.isEmpty) {
@@ -431,6 +452,11 @@ class _GalleryPageState extends State<GalleryPage> {
                 inputFormatters: <TextInputFormatter>[
                   FilteringTextInputFormatter.digitsOnly
                 ],
+                resetText: () => settingsHandler.map['galleryAutoScrollTime']?['default']?.toString() ?? "4000",
+                numberButtons: true,
+                numberStep: 100,
+                numberMin: 100,
+                numberMax: double.infinity,
                 validator: (String? value) {
                   int? parse = int.tryParse(value ?? '');
                   if(value == null || value.isEmpty) {
@@ -442,7 +468,7 @@ class _GalleryPageState extends State<GalleryPage> {
                   }
                 },
                 trailingIcon: IconButton(
-                  icon: Icon(Icons.info, color: Get.theme.colorScheme.secondary),
+                  icon: Icon(Icons.help_outline),
                   onPressed: () {
                     showDialog(
                       context: context,

--- a/lib/pages/settings/SaveCachePage.dart
+++ b/lib/pages/settings/SaveCachePage.dart
@@ -2,8 +2,6 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:isolate';
 
-
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
@@ -112,7 +110,7 @@ class _SaveCachePageState extends State<SaveCachePage> {
     settingsHandler.cacheDuration = cacheDuration;
     settingsHandler.cacheSize = int.parse(cacheSizeController.text);
     settingsHandler.extPathOverride = extPathOverride;
-    bool result = await settingsHandler.saveSettings(restate: true);
+    bool result = await settingsHandler.saveSettings(restate: false);
     return result;
   }
 
@@ -143,6 +141,11 @@ class _SaveCachePageState extends State<SaveCachePage> {
                 inputFormatters: <TextInputFormatter>[
                   FilteringTextInputFormatter.digitsOnly
                 ],
+                resetText: () => settingsHandler.map['snatchCooldown']?['default']?.toString() ?? "250",
+                numberButtons: true,
+                numberStep: 50,
+                numberMin: 0,
+                numberMax: double.infinity,
                 validator: (String? value) {
                   int? parse = int.tryParse(value ?? '');
                   if(value == null || value.isEmpty) {
@@ -247,7 +250,7 @@ class _SaveCachePageState extends State<SaveCachePage> {
                 },
                 title: 'Video Cache Mode',
                 trailingIcon: IconButton(
-                  icon: Icon(Icons.info, color: Get.theme.colorScheme.secondary),
+                  icon: Icon(Icons.help_outline),
                   onPressed: () {
                     showDialog(
                       context: context,
@@ -294,6 +297,11 @@ class _SaveCachePageState extends State<SaveCachePage> {
                 inputFormatters: <TextInputFormatter>[
                   FilteringTextInputFormatter.digitsOnly
                 ],
+                resetText: () => settingsHandler.map['cacheSize']?['default']?.toString() ?? "3",
+                numberButtons: true,
+                numberStep: 1,
+                numberMin: 0,
+                numberMax: double.infinity,
               ),
 
               SettingsButton(name: '', enabled: false),

--- a/lib/pages/settings/ThemePage.dart
+++ b/lib/pages/settings/ThemePage.dart
@@ -66,14 +66,14 @@ class _ThemePageState extends State<ThemePage> {
     //and you back out too fast the image path will not be returned in time to save it to settings
     if (needToWriteMascot) {
       if (mascotPathOverride.isNotEmpty) {
-        mascotPathOverride = await new ImageWriter().writeMascotImage(mascotPathOverride);
+        mascotPathOverride = await ImageWriter().writeMascotImage(mascotPathOverride);
         settingsHandler.drawerMascotPathOverride = mascotPathOverride;
         needToWriteMascot = false;
       }
     } else {
       settingsHandler.drawerMascotPathOverride = mascotPathOverride;
     }
-    bool result = await settingsHandler.saveSettings(restate: true);
+    bool result = await settingsHandler.saveSettings(restate: false);
     return result;
   }
 
@@ -365,7 +365,7 @@ class _ThemePageState extends State<ThemePage> {
                   icon: Icon(Icons.delete_forever),
                   drawTopBorder: true,
                   action: () async{
-                    File file = new File(mascotPathOverride);
+                    File file = File(mascotPathOverride);
                     if (file.existsSync()) {
                       file.deleteSync();
                     }

--- a/lib/pages/settings/UserInterfacePage.dart
+++ b/lib/pages/settings/UserInterfacePage.dart
@@ -1,10 +1,11 @@
-import 'package:LoliSnatcher/widgets/SettingsWidgets.dart';
-import 'package:flutter/cupertino.dart';
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 
-import '../../SettingsHandler.dart';
+import 'package:LoliSnatcher/SettingsHandler.dart';
+import 'package:LoliSnatcher/widgets/SettingsWidgets.dart';
 
 class UserInterfacePage extends StatefulWidget {
   UserInterfacePage();
@@ -41,7 +42,7 @@ class _UserInterfacePageState extends State<UserInterfacePage> {
     }
     settingsHandler.landscapeColumns = int.parse(columnsLandscapeController.text);
     settingsHandler.portraitColumns = int.parse(columnsPortraitController.text);
-    bool result = await settingsHandler.saveSettings(restate: true);
+    bool result = await settingsHandler.saveSettings(restate: false);
     return result;
   }
 
@@ -67,7 +68,7 @@ class _UserInterfacePageState extends State<UserInterfacePage> {
                 },
                 title: 'App UI Mode',
                 trailingIcon: IconButton(
-                  icon: Icon(Icons.info, color: Get.theme.colorScheme.secondary),
+                  icon: Icon(Icons.help_outline),
                   onPressed: () {
                     Get.dialog(
                       SettingsDialog(
@@ -93,12 +94,22 @@ class _UserInterfacePageState extends State<UserInterfacePage> {
                 inputFormatters: <TextInputFormatter>[
                   FilteringTextInputFormatter.digitsOnly
                 ],
+                onChanged: (String? text) {
+                  setState(() { });
+                },
+                resetText: () => settingsHandler.map['portraitColumns']?['default']?.toString() ?? "2",
+                numberButtons: true,
+                numberStep: 1,
+                numberMin: 1,
+                numberMax: double.infinity,
                 validator: (String? value) {
                   int? parse = int.tryParse(value ?? '');
                   if(value == null || value.isEmpty) {
                     return 'Please enter a value';
                   } else if(parse == null) {
                     return 'Please enter a valid numeric value';
+                  } else if(parse > 3 && (Platform.isAndroid || Platform.isIOS)) {
+                    return 'More than 3 columns could affect performance';
                   } else {
                     return null;
                   }
@@ -112,6 +123,11 @@ class _UserInterfacePageState extends State<UserInterfacePage> {
                 inputFormatters: <TextInputFormatter>[
                   FilteringTextInputFormatter.digitsOnly
                 ],
+                resetText: () => settingsHandler.map['landscapeColumns']?['default']?.toString() ?? "4",
+                numberButtons: true,
+                numberStep: 1,
+                numberMin: 1,
+                numberMax: double.infinity,
                 validator: (String? value) {
                   int? parse = int.tryParse(value ?? '');
                   if(value == null || value.isEmpty) {
@@ -133,7 +149,7 @@ class _UserInterfacePageState extends State<UserInterfacePage> {
                 },
                 title: 'Preview Quality',
                 trailingIcon: IconButton(
-                  icon: Icon(Icons.info, color: Get.theme.colorScheme.secondary),
+                  icon: Icon(Icons.help_outline),
                   onPressed: () {
                     Get.dialog(
                       SettingsDialog(

--- a/lib/pages/settings/settingstemplate.dart
+++ b/lib/pages/settings/settingstemplate.dart
@@ -20,7 +20,7 @@ class _SettingsTemplateState extends State<SettingsTemplate> {
   //called when page is clsoed, sets settingshandler variables and then writes settings to disk
   Future<bool> _onWillPop() async {
     // Set settingshandler values here
-    bool result = await settingsHandler.saveSettings(restate: true);
+    bool result = await settingsHandler.saveSettings(restate: false);
     return result;
   }
 

--- a/lib/utilities/html_color.dart
+++ b/lib/utilities/html_color.dart
@@ -1,0 +1,305 @@
+import 'package:flutter/painting.dart';
+
+const _kColorMap = <String, Color>{
+  'aliceblue': Color(0xFFF0F8FF),
+  'antiquewhite': Color(0xFFFAEBD7),
+  'aqua': Color(0xFF00FFFF),
+  'aquamarine': Color(0xFF7FFFD4),
+  'azure': Color(0xFFF0FFFF),
+  'beige': Color(0xFFF5F5DC),
+  'bisque': Color(0xFFFFE4C4),
+  'black': Color(0xFF000000),
+  'blanchedalmond': Color(0xFFFFEBCD),
+  'blue': Color(0xFF0000FF),
+  'blueviolet': Color(0xFF8A2BE2),
+  'brown': Color(0xFFA52A2A),
+  'burlywood': Color(0xFFDEB887),
+  'cadetblue': Color(0xFF5F9EA0),
+  'chartreuse': Color(0xFF7FFF00),
+  'chocolate': Color(0xFFD2691E),
+  'coral': Color(0xFFFF7F50),
+  'cornflowerblue': Color(0xFF6495ED),
+  'cornsilk': Color(0xFFFFF8DC),
+  'crimson': Color(0xFFDC143C),
+  'cyan': Color(0xFF00FFFF),
+  'darkblue': Color(0xFF00008B),
+  'darkcyan': Color(0xFF008B8B),
+  'darkgoldenrod': Color(0xFFB8860B),
+  'darkgray': Color(0xFFA9A9A9),
+  'darkgrey': Color(0xFFA9A9A9),
+  'darkgreen': Color(0xFF006400),
+  'darkkhaki': Color(0xFFBDB76B),
+  'darkmagenta': Color(0xFF8B008B),
+  'darkolivegreen': Color(0xFF556B2F),
+  'darkorange': Color(0xFFFF8C00),
+  'darkorchid': Color(0xFF9932CC),
+  'darkred': Color(0xFF8B0000),
+  'darksalmon': Color(0xFFE9967A),
+  'darkseagreen': Color(0xFF8FBC8F),
+  'darkslateblue': Color(0xFF483D8B),
+  'darkslategray': Color(0xFF2F4F4F),
+  'darkslategrey': Color(0xFF2F4F4F),
+  'darkturquoise': Color(0xFF00CED1),
+  'darkviolet': Color(0xFF9400D3),
+  'deeppink': Color(0xFFFF1493),
+  'deepskyblue': Color(0xFF00BFFF),
+  'dimgray': Color(0xFF696969),
+  'dimgrey': Color(0xFF696969),
+  'dodgerblue': Color(0xFF1E90FF),
+  'firebrick': Color(0xFFB22222),
+  'floralwhite': Color(0xFFFFFAF0),
+  'forestgreen': Color(0xFF228B22),
+  'fuchsia': Color(0xFFFF00FF),
+  'gainsboro': Color(0xFFDCDCDC),
+  'ghostwhite': Color(0xFFF8F8FF),
+  'gold': Color(0xFFFFD700),
+  'goldenrod': Color(0xFFDAA520),
+  'gray': Color(0xFF808080),
+  'grey': Color(0xFF808080),
+  'green': Color(0xFF008000),
+  'greenyellow': Color(0xFFADFF2F),
+  'honeydew': Color(0xFFF0FFF0),
+  'hotpink': Color(0xFFFF69B4),
+  'indianred': Color(0xFFCD5C5C),
+  'indigo': Color(0xFF4B0082),
+  'ivory': Color(0xFFFFFFF0),
+  'khaki': Color(0xFFF0E68C),
+  'lavender': Color(0xFFE6E6FA),
+  'lavenderblush': Color(0xFFFFF0F5),
+  'lawngreen': Color(0xFF7CFC00),
+  'lemonchiffon': Color(0xFFFFFACD),
+  'lightblue': Color(0xFFADD8E6),
+  'lightcoral': Color(0xFFF08080),
+  'lightcyan': Color(0xFFE0FFFF),
+  'lightgoldenrodyellow': Color(0xFFFAFAD2),
+  'lightgray': Color(0xFFD3D3D3),
+  'lightgrey': Color(0xFFD3D3D3),
+  'lightgreen': Color(0xFF90EE90),
+  'lightpink': Color(0xFFFFB6C1),
+  'lightsalmon': Color(0xFFFFA07A),
+  'lightseagreen': Color(0xFF20B2AA),
+  'lightskyblue': Color(0xFF87CEFA),
+  'lightslategray': Color(0xFF778899),
+  'lightslategrey': Color(0xFF778899),
+  'lightsteelblue': Color(0xFFB0C4DE),
+  'lightyellow': Color(0xFFFFFFE0),
+  'lime': Color(0xFF00FF00),
+  'limegreen': Color(0xFF32CD32),
+  'linen': Color(0xFFFAF0E6),
+  'magenta': Color(0xFFFF00FF),
+  'maroon': Color(0xFF800000),
+  'mediumaquamarine': Color(0xFF66CDAA),
+  'mediumblue': Color(0xFF0000CD),
+  'mediumorchid': Color(0xFFBA55D3),
+  'mediumpurple': Color(0xFF9370DB),
+  'mediumseagreen': Color(0xFF3CB371),
+  'mediumslateblue': Color(0xFF7B68EE),
+  'mediumspringgreen': Color(0xFF00FA9A),
+  'mediumturquoise': Color(0xFF48D1CC),
+  'mediumvioletred': Color(0xFFC71585),
+  'midnightblue': Color(0xFF191970),
+  'mintcream': Color(0xFFF5FFFA),
+  'mistyrose': Color(0xFFFFE4E1),
+  'moccasin': Color(0xFFFFE4B5),
+  'navajowhite': Color(0xFFFFDEAD),
+  'navy': Color(0xFF000080),
+  'oldlace': Color(0xFFFDF5E6),
+  'olive': Color(0xFF808000),
+  'olivedrab': Color(0xFF6B8E23),
+  'orange': Color(0xFFFFA500),
+  'orangered': Color(0xFFFF4500),
+  'orchid': Color(0xFFDA70D6),
+  'palegoldenrod': Color(0xFFEEE8AA),
+  'palegreen': Color(0xFF98FB98),
+  'paleturquoise': Color(0xFFAFEEEE),
+  'palevioletred': Color(0xFFDB7093),
+  'papayawhip': Color(0xFFFFEFD5),
+  'peachpuff': Color(0xFFFFDAB9),
+  'peru': Color(0xFFCD853F),
+  'pink': Color(0xFFFFC0CB),
+  'plum': Color(0xFFDDA0DD),
+  'powderblue': Color(0xFFB0E0E6),
+  'purple': Color(0xFF800080),
+  'rebeccapurple': Color(0xFF663399),
+  'red': Color(0xFFFF0000),
+  'rosybrown': Color(0xFFBC8F8F),
+  'royalblue': Color(0xFF4169E1),
+  'saddlebrown': Color(0xFF8B4513),
+  'salmon': Color(0xFFFA8072),
+  'sandybrown': Color(0xFFF4A460),
+  'seagreen': Color(0xFF2E8B57),
+  'seashell': Color(0xFFFFF5EE),
+  'sienna': Color(0xFFA0522D),
+  'silver': Color(0xFFC0C0C0),
+  'skyblue': Color(0xFF87CEEB),
+  'slateblue': Color(0xFF6A5ACD),
+  'slategray': Color(0xFF708090),
+  'slategrey': Color(0xFF708090),
+  'snow': Color(0xFFFFFAFA),
+  'springgreen': Color(0xFF00FF7F),
+  'steelblue': Color(0xFF4682B4),
+  'tan': Color(0xFFD2B48C),
+  'teal': Color(0xFF008080),
+  'thistle': Color(0xFFD8BFD8),
+  'tomato': Color(0xFFFF6347),
+  'turquoise': Color(0xFF40E0D0),
+  'violet': Color(0xFFEE82EE),
+  'wheat': Color(0xFFF5DEB3),
+  'white': Color(0xFFFFFFFF),
+  'whitesmoke': Color(0xFFF5F5F5),
+  'yellow': Color(0xFFFFFF00),
+  'yellowgreen': Color(0xFF9ACD32),
+};
+
+Color parse(String text) {
+  text = text.trim();
+  if (text.isEmpty) throw FormatException('Empty html color: $text');
+
+  if (text.codeUnitAt(0) == '#'.codeUnitAt(0)) {
+    if (text.length >= 7) {
+      // #ff0000
+      return Color(0xFF000000 | int.parse(text.substring(1, 7), radix: 16));
+    } else if (text.length >= 4) {
+      // #f00
+      final color = int.parse(text.substring(1, 4), radix: 16);
+      final r = color & 0xF00;
+      final g = color & 0xF0;
+      final b = color & 0xF;
+      return Color(0xFF000000 | r << 12 | r << 8 | g << 8 | g << 4 | b << 4 | b);
+    }
+  } else if (text.startsWith('rgb(') && text.endsWith(')')) {
+    // rgb(255, 0, 0)
+    // rgb(100%, 0%, 0%)
+    String str = text.substring(4, text.length - 1);
+    List<String> colors = str.split(',');
+    if (colors.length >= 3) {
+      final r = _parseRGB(colors[0]);
+      final g = _parseRGB(colors[1]);
+      final b = _parseRGB(colors[2]);
+      return Color.fromARGB(0xFF, r, g, b);
+    }
+  } else if (text.startsWith('rgba(') && text.endsWith(')')) {
+    // rgba(255, 0, 0, 0.6)
+    // rgba(100%, 0%, 0%, 0.6)
+    String str = text.substring(5, text.length - 1);
+    List<String> colors = str.split(',');
+    if (colors.length >= 4) {
+      int r = _parseRGB(colors[0]);
+      int g = _parseRGB(colors[1]);
+      int b = _parseRGB(colors[2]);
+      int a = _parseA(colors[3]);
+      return Color.fromARGB(a, r, g, b);
+    }
+  } else if (text.startsWith('hsl(') && text.endsWith(')')) {
+    // hsl(120, 100%, 50%)
+    String str = text.substring(4, text.length - 1);
+    List<String> colors = str.split(',');
+    if (colors.length >= 3) {
+      final h = _parseH(colors[0]);
+      final s = _parseSL(colors[1]);
+      final l = _parseSL(colors[2]);
+      return _hslaToColor(h, s, l, 0xFF);
+    }
+  } else if (text.startsWith('hsla(') && text.endsWith(')')) {
+    // hsla(120, 100%, 25%, 0.3)
+    String str = text.substring(5, text.length - 1);
+    List<String> colors = str.split(',');
+    if (colors.length >= 4) {
+      final h = _parseH(colors[0]);
+      final s = _parseSL(colors[1]);
+      final l = _parseSL(colors[2]);
+      final a = _parseA(colors[3]);
+      return _hslaToColor(h, s, l, a);
+    }
+  }
+
+  final color = _kColorMap[text.toLowerCase()];
+  if (color == null) throw FormatException('Invalid html color: $text');
+  return color;
+}
+
+Color? tryParse(String text) {
+  try {
+    return parse(text);
+  } on FormatException {
+    return null;
+  }
+}
+
+int _parseRGB(String text) {
+  text = text.trim();
+  int i;
+  if (text.endsWith('%')) {
+    i = (255 * int.parse(text.substring(0, text.length - 1)) / 100).round();
+  } else {
+    i = int.parse(text);
+  }
+  return i.clamp(0, 255);
+}
+
+int _parseA(String text) {
+  return (255 * double.parse(text.trim())).round().clamp(0, 255);
+}
+
+int _parseH(String text) {
+  return int.parse(text.trim()) % 360;
+}
+
+double _parseSL(String text) {
+  text = text.trim();
+  if (text.endsWith('%')) {
+    final f = int.parse(text.substring(0, text.length - 1)) / 100;
+    return f.clamp(0, 1);
+  }
+  throw FormatException('Invalid s or l in HSL: $text');
+}
+
+Color _hslaToColor(int h, double s, double l, int a) {
+  final c = (1 - (2 * l - 1).abs()) * s;
+  final m = l - 0.5 * c;
+  final x = c * (1 - ((h / 60 % 2) - 1).abs());
+
+  final hueSegment = h ~/ 60;
+
+  var r = 0, g = 0, b = 0;
+
+  switch (hueSegment) {
+    case 0:
+      r = (255 * (c + m)).round();
+      g = (255 * (x + m)).round();
+      b = (255 * m).round();
+      break;
+    case 1:
+      r = (255 * (x + m)).round();
+      g = (255 * (c + m)).round();
+      b = (255 * m).round();
+      break;
+    case 2:
+      r = (255 * m).round();
+      g = (255 * (c + m)).round();
+      b = (255 * (x + m)).round();
+      break;
+    case 3:
+      r = (255 * m).round();
+      g = (255 * (x + m)).round();
+      b = (255 * (c + m)).round();
+      break;
+    case 4:
+      r = (255 * (x + m)).round();
+      g = (255 * m).round();
+      b = (255 * (c + m)).round();
+      break;
+    case 5:
+    default:
+      r = (255 * (c + m)).round();
+      g = (255 * m).round();
+      b = (255 * (x + m)).round();
+      break;
+  }
+
+  r = r.clamp(0, 255);
+  g = g.clamp(0, 255);
+  b = b.clamp(0, 255);
+
+  return Color.fromARGB(a, r, g, b);
+}

--- a/lib/utilities/html_parse.dart
+++ b/lib/utilities/html_parse.dart
@@ -1,0 +1,179 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart';
+import 'package:html/dom.dart' as dom;
+import 'package:html/parser.dart' as parser;
+
+import 'html_color.dart' as htmlColor;
+
+// Original code: https://gist.github.com/seven332/9dc76255d959c8c5194cbd92068b0f60
+
+// TODO Add tag handler
+// TODO Add GestureRecognizer for a tag
+InlineSpan parse(String html, TextStyle style, bool isBordered) {
+  final document = parser.parse(html);
+  final span = _parseRecursive(document.body, style, true, isBordered);
+  return span;
+}
+
+InlineSpan _parseRecursive(dynamic node, TextStyle style, bool styleChanged, bool isBordered) {
+  if (node is dom.Text) {
+    return _parseText(node, style, styleChanged, isBordered);
+  } else if (node is dom.Element) {
+    return _parseElement(node, style, styleChanged, isBordered);
+  } else {
+    return _parseOtherNode(node, style, styleChanged, isBordered);
+  }
+}
+
+// TODO the method always remove whitespace at leading,
+//  but it should check the tail of the previous span
+String _fixWhitespaceInText(String text) {
+  final sb = new StringBuffer();
+  int pre = ' '.codeUnitAt(0);
+  for (int c in text.codeUnits) {
+    if (c == ' '.codeUnitAt(0) || c == '\n'.codeUnitAt(0)) {
+      if (pre != ' '.codeUnitAt(0) && pre != '\n'.codeUnitAt(0)) {
+        sb.writeCharCode(' '.codeUnitAt(0));
+        pre = c;
+      }
+    } else {
+      sb.writeCharCode(c);
+      pre = c;
+    }
+  }
+  return sb.toString();
+}
+
+InlineSpan _parseText(dom.Text text, TextStyle style, bool styleChanged, bool isBordered) {
+  var t = text.data;
+  if (t == null || t.isEmpty) return TextSpan(text: '');
+  // t = _fixWhitespaceInText(t);
+  return TextSpan(text: t, style: styleChanged ? style : null);
+}
+
+TextDecoration _combine(TextDecoration? nullable, TextDecoration nonnull) {
+  if (nullable == null) return nonnull;
+  else return TextDecoration.combine([nullable, nonnull]);
+}
+
+InlineSpan _parseElement(dom.Element element, TextStyle style, bool styleChanged, bool isBordered) {
+  final tag = element.localName?.toLowerCase();
+
+  GestureRecognizer? recognizer;
+
+  switch (tag) {
+    case "body":
+    case "span": //?
+    case "div": //?
+      // Ignore
+      break;
+    case "br":
+      return TextSpan(text: "\n", style: styleChanged ? style : null);
+    case "strong":
+    case "b":
+      style = style.copyWith(fontWeight: FontWeight.bold);
+      styleChanged = true;
+      break;
+    case "em":
+    case "cite":
+    case "dfn":
+    case "i":
+      style = style.copyWith(fontStyle: FontStyle.italic);
+      styleChanged = true;
+      break;
+    case "u":
+    case "ins":
+      style = style.copyWith(decoration: _combine(style.decoration, TextDecoration.underline));
+      styleChanged = true;
+      break;
+    case "del":
+    case "s":
+    case "strike":
+      style = style.copyWith(decoration: _combine(style.decoration, TextDecoration.lineThrough));
+      styleChanged = true;
+      break;
+    case "small":
+      style = style.copyWith(fontSize: (style.fontSize ?? 14) - 2);
+      styleChanged = true;
+      break;
+    case "big":
+      style = style.copyWith(fontSize: (style.fontSize ?? 14) + 2);
+      styleChanged = true;
+      break;
+    case "tn":
+      element.text = 'Translator note: ' + element.text;
+      style = style.copyWith(fontSize: (style.fontSize ?? 14) - 2);
+      styleChanged = true;
+      break;
+    case "font":
+      Color? color = htmlColor.tryParse(element.attributes['color'] ?? '');
+      if (color != null) {
+        style = style.copyWith(color: color);
+        styleChanged = true;
+      }
+      break;
+    default:
+      print("Unhandled tag: $tag");
+      break;
+  }
+
+  if(isBordered) {
+    Paint paint = Paint()
+      ..color = Colors.black.withOpacity(0.75)
+      ..style = PaintingStyle.fill
+      ..strokeCap = StrokeCap.round
+      ..strokeWidth = 2.0;
+
+    style = style.copyWith(
+      background: paint
+    );
+    styleChanged = true;
+  }
+
+  return _parseParent(element, style, styleChanged, recognizer, isBordered);
+}
+
+InlineSpan _parseOtherNode(dom.Node node, TextStyle style, bool styleChanged, bool isBordered) {
+  return _parseParent(node, style, styleChanged, null, isBordered);
+}
+
+InlineSpan _parseParent(
+  dom.Node node,
+  TextStyle style,
+  bool styleChanged,
+  GestureRecognizer? recognizer,
+  bool isBordered,
+) {
+  final List<InlineSpan> children = [];
+  node.nodes.forEach((item) {
+    // The change of style is applied below
+    var span = _parseRecursive(item, style, false, isBordered);
+    children.add(span);
+  });
+
+  // Avoid TextSpan with no child
+  if (children.length == 0) return TextSpan(text: '');
+
+  // Avoid TextSpan with only one child
+  if (children.length == 1) {
+    final span = children.single;
+    if (span is TextSpan) {
+      // Keep origin style/recognizer, or use parent style/recognizer
+      if ((span.style != null || !styleChanged) &&
+        (span.recognizer != null || recognizer == null))
+        return span;
+      else return TextSpan(
+        text: span.text,
+        style: span.style != null ? span.style : style,
+        recognizer: span.recognizer != null ? span.recognizer : recognizer,
+      );
+    }
+    // TODO what if it's not TextSpan
+  }
+
+  return TextSpan(
+    children: children,
+    style: styleChanged ? style : null,
+    recognizer: recognizer,
+  );
+}

--- a/lib/widgets/ActiveTitle.dart
+++ b/lib/widgets/ActiveTitle.dart
@@ -1,17 +1,9 @@
 import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
 
-import '../SnatchHandler.dart';
+import 'package:LoliSnatcher/SnatchHandler.dart';
 
-class ActiveTitle extends StatefulWidget {
-  ActiveTitle();
-
-  @override
-  _ActiveTitleState createState() => _ActiveTitleState();
-  
-}
-
-class _ActiveTitleState extends State<ActiveTitle> {
+class ActiveTitle extends StatelessWidget {
   final SnatchHandler snatchHandler = Get.find<SnatchHandler>();
 
   @override

--- a/lib/widgets/BooruSelectorMain.dart
+++ b/lib/widgets/BooruSelectorMain.dart
@@ -1,5 +1,4 @@
 import 'package:dropdown_search/dropdown_search.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
@@ -192,6 +191,7 @@ class _BooruSelectorMainState extends State<BooruSelectorMain> {
             isExpanded: true,
             value: searchHandler.currentTab.selectedBooru.value,
             icon: Icon(Icons.arrow_drop_down),
+            itemHeight: kMinInteractiveDimension,
             decoration: InputDecoration(
               labelText: 'Booru',
               labelStyle: TextStyle(color: Get.theme.colorScheme.onBackground, fontSize: 18),

--- a/lib/widgets/CachedFavicon.dart
+++ b/lib/widgets/CachedFavicon.dart
@@ -1,9 +1,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 
-import 'package:flutter/widgets.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:dio/dio.dart';
 import 'package:get/get.dart';
 

--- a/lib/widgets/CachedThumbBetter.dart
+++ b/lib/widgets/CachedThumbBetter.dart
@@ -1,10 +1,8 @@
-import 'dart:ui';
 import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:get/get.dart';
 import 'package:transparent_image/transparent_image.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:dio/dio.dart';
@@ -169,7 +167,7 @@ class _CachedThumbBetterState extends State<CachedThumbBetter> {
     _total.value = total;
   }
 
-  void _onEvent(String event) {
+  void _onEvent(String event, dynamic value) {
     switch (event) {
       case 'loaded':
         // 
@@ -241,7 +239,9 @@ class _CachedThumbBetterState extends State<CachedThumbBetter> {
     // restart loading if item was marked as hated
     hateListener = widget.booruItem.isHated.listen((bool value) {
       if(value == true) {
-        restartLoading();
+        WidgetsBinding.instance!.addPostFrameCallback((_) {
+          restartLoading();
+        });
       }
     });
 
@@ -341,7 +341,7 @@ class _CachedThumbBetterState extends State<CachedThumbBetter> {
     double screenWidth = MediaQuery.of(context).size.width;
     double iconSize = (screenWidth / widget.columnCount) * 0.55;
 
-    return Obx(() => Stack(
+    return Stack(
       alignment: Alignment.center,
       children: [
         if(isThumbQuality == false && !widget.booruItem.isHated.value) // fetch thumbnail from network while loading a sample
@@ -412,7 +412,7 @@ class _CachedThumbBetterState extends State<CachedThumbBetter> {
             child: Text(thumbURL),
           ),
       ]
-    ));
+    );
   }
 
   @override

--- a/lib/widgets/ChangePageButtons.dart
+++ b/lib/widgets/ChangePageButtons.dart
@@ -1,0 +1,140 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:preload_page_view/preload_page_view.dart';
+
+import 'package:LoliSnatcher/ServiceHandler.dart';
+import 'package:LoliSnatcher/SearchGlobals.dart';
+import 'package:LoliSnatcher/SettingsHandler.dart';
+import 'package:LoliSnatcher/ViewerHandler.dart';
+import 'package:LoliSnatcher/libBooru/BooruItem.dart';
+
+class ChangePageButtons extends StatefulWidget {
+  final PreloadPageController? controller;
+  ChangePageButtons(this.controller, {Key? key}) : super(key: key);
+
+  @override
+  _ChangePageButtonsState createState() => _ChangePageButtonsState();
+}
+
+class _ChangePageButtonsState extends State<ChangePageButtons> {
+  final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
+  final SearchHandler searchHandler = Get.find<SearchHandler>();
+  final ViewerHandler viewerHandler = Get.find<ViewerHandler>();
+
+  bool isVisible = false;
+  double bottomOffset = kToolbarHeight * 2;
+
+  StreamSubscription<bool>? appbarListener;
+  StreamSubscription<BooruItem>? itemListener;
+
+  Timer? longPressTimer;
+  int repeatCount = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    isVisible = settingsHandler.changePageButtonsPosition != "Disabled" && settingsHandler.appMode == "Mobile" && viewerHandler.displayAppbar.value;
+    appbarListener = viewerHandler.displayAppbar.listen((bool value) {
+      if (settingsHandler.changePageButtonsPosition != "Disabled" && settingsHandler.appMode == "Mobile") {
+        isVisible = value;
+      }
+      updateState();
+    });
+
+    bottomOffset = searchHandler.viewedItem.value.isVideo() ? kToolbarHeight * 3 : kToolbarHeight * 2;
+    itemListener = searchHandler.viewedItem.listen((BooruItem item) {
+      if (item.isVideo()) {
+        bottomOffset = kToolbarHeight * 3;
+      } else {
+        bottomOffset = kToolbarHeight * 2;
+      }
+      updateState();
+    });
+  }
+
+  void updateState() {
+    if (this.mounted) {
+      setState(() {});
+    }
+  }
+
+  @override
+  void dispose() {
+    appbarListener?.cancel();
+    itemListener?.cancel();
+    super.dispose();
+  }
+
+  void changePage(int direction) {
+    if (widget.controller?.hasClients ?? false) {
+      if(repeatCount > 0) {
+        ServiceHandler.vibrate(duration: 2);
+      }
+      widget.controller!.jumpToPage(((widget.controller!.page ?? 0) + direction).round());
+    }
+  }
+
+  Widget buildButton(IconData icon, int direction) {
+    final int fasterAfter = 20;
+
+    return GestureDetector(
+      onLongPressStart: (details) {
+        // repeat every 100ms if the user holds down the button
+        if (longPressTimer != null) return;
+        longPressTimer = Timer.periodic(Duration(milliseconds: 200), (timer) {
+          changePage(direction);
+          repeatCount++;
+
+          // repeat faster after a certain amount of times
+          if (repeatCount > fasterAfter) {
+            longPressTimer?.cancel();
+            longPressTimer = Timer.periodic(Duration(milliseconds: 100), (timer) {
+              changePage(direction);
+              repeatCount++;
+            });
+          }
+        });
+      },
+      onLongPressEnd: (details) {
+        // stop repeating if the user releases the button
+        longPressTimer?.cancel();
+        longPressTimer = null;
+        repeatCount = 0;
+      },
+      onLongPressCancel: () {
+        // stop repeating if the user moves the finger/mouse away
+        longPressTimer?.cancel();
+        longPressTimer = null;
+        repeatCount = 0;
+      },
+      child: IconButton(
+        icon: Icon(icon, color: Colors.grey.withOpacity(0.5), size: 36),
+        onPressed: () {
+          changePage(direction);
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (isVisible) {
+      return AnimatedPositioned(
+        duration: Duration(milliseconds: 200),
+        bottom: bottomOffset,
+        right: settingsHandler.changePageButtonsPosition == "Right" ? 40 : null,
+        left: settingsHandler.changePageButtonsPosition == "Left" ? 40 : null,
+        child: Row(
+          children: <Widget>[
+            buildButton(Icons.arrow_back_ios, -1),
+            buildButton(Icons.arrow_forward_ios, 1),
+          ],
+        ),
+      );
+    } else {
+      return const SizedBox();
+    }
+  }
+}

--- a/lib/widgets/CommentsDialog.dart
+++ b/lib/widgets/CommentsDialog.dart
@@ -1,5 +1,3 @@
-
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:flutter_linkify/flutter_linkify.dart';
@@ -85,7 +83,7 @@ class _CommentsDialogState extends State<CommentsDialog> {
     isLoading = true;
     if (widget.item.serverId != null) {
       setState(() {}); // set state to update the loading indicator
-      var fetched = await searchHandler.currentTab.booruHandler.fetchComments(widget.item.serverId!, 0);
+      var fetched = await searchHandler.currentBooruHandler.fetchComments(widget.item.serverId!, 0);
       comments = fetched;
     } else {
       notSupported = true;

--- a/lib/widgets/FlashElements.dart
+++ b/lib/widgets/FlashElements.dart
@@ -6,6 +6,7 @@ import 'package:get/get.dart';
 
 import 'package:LoliSnatcher/ViewerHandler.dart';
 import 'package:LoliSnatcher/SettingsHandler.dart';
+import 'package:LoliSnatcher/widgets/SettingsWidgets.dart';
 
 enum Positions {
   bottom,
@@ -27,6 +28,7 @@ class FlashElements {
     bool shouldLeadingPulse = true, // should icon widget play pulse animation
     bool allowInViewer = true, // should tip open when user is in viewer
     Positions position = Positions.bottom,
+    bool asDialog = false,
   }) {
     bool inViewer = Get.find<ViewerHandler>().inViewer.value;
     if(!allowInViewer && inViewer) {
@@ -41,6 +43,39 @@ class FlashElements {
     bool isDark = Get.theme.brightness == Brightness.dark;
 
     FlashPosition flashPosition = position == Positions.bottom ? FlashPosition.bottom : FlashPosition.top;
+
+    if(asDialog) {
+      showDialog(context: context ?? Get.context!, builder: (context) {
+        return SettingsDialog(
+          titlePadding: const EdgeInsets.all(0),
+          buttonPadding: const EdgeInsets.all(0),
+          contentPadding: const EdgeInsets.all(0),
+          insetPadding: const EdgeInsets.all(0),
+          borderRadius: BorderRadius.all(Radius.circular(8)),
+          content: DefaultTextStyle(
+            style: TextStyle(color: Get.theme.colorScheme.onBackground),
+            child: ClipRRect(
+              borderRadius: BorderRadius.all(Radius.circular(8)),
+              child: FlashBar(
+                title: title,
+                content: content,
+                indicatorColor: sideColor,
+                icon: overrideLeadingIconWidget ?? Padding(
+                  padding: EdgeInsets.all(12),
+                  child: Icon(
+                    leadingIcon,
+                    color: leadingIconColor ?? Get.theme.colorScheme.onBackground,
+                    size: leadingIconSize,
+                  )
+                ),
+                shouldIconPulse: shouldLeadingPulse,
+              ),
+            ),
+          ),
+        );
+      });
+      return;
+    }
 
     showFlash(
       context: context ?? Get.context!,

--- a/lib/widgets/GridBuilder.dart
+++ b/lib/widgets/GridBuilder.dart
@@ -1,0 +1,47 @@
+import 'package:LoliSnatcher/SearchGlobals.dart';
+import 'package:LoliSnatcher/SettingsHandler.dart';
+import 'package:LoliSnatcher/widgets/ThumbCardBuild.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class GridBuilder extends StatelessWidget {
+  final onTap;
+  GridBuilder(this.onTap, {Key? key}) : super(key: key);
+
+  final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
+  final SearchHandler searchHandler = Get.find<SearchHandler>();
+
+  @override
+  Widget build(BuildContext context) {
+    return Obx(() {
+      int columnCount =
+        (MediaQuery.of(context).orientation == Orientation.portrait)
+            ? settingsHandler.portraitColumns
+            : settingsHandler.landscapeColumns;
+
+      bool isDesktop = settingsHandler.appMode == 'Desktop';
+
+      return GridView.builder(
+        controller: searchHandler.gridScrollController,
+        physics: const BouncingScrollPhysics(parent: const AlwaysScrollableScrollPhysics()),
+        addAutomaticKeepAlives: false,
+        cacheExtent: 200,
+        shrinkWrap: false,
+        itemCount: searchHandler.currentFetched.length,
+        padding: EdgeInsets.fromLTRB(2, 2 + (isDesktop ? 0 : (kToolbarHeight + MediaQuery.of(context).padding.top)), 2, 80),
+        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: columnCount,
+          childAspectRatio: settingsHandler.previewDisplay == 'Square' ? 1 : 9/16
+        ),
+        itemBuilder: (BuildContext context, int index) {
+          return Card(
+            margin: EdgeInsets.all(2),
+            child: GridTile(
+              child: ThumbCardBuild(index, columnCount, onTap, searchHandler.currentTab),
+            ),
+          );
+        },
+      );
+    });;
+  }
+}

--- a/lib/widgets/HideableAppbar.dart
+++ b/lib/widgets/HideableAppbar.dart
@@ -1,13 +1,9 @@
 import 'dart:async';
-import 'dart:ui';
-
 
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 import 'package:LoliSnatcher/ViewerHandler.dart';
-
-// import 'package:flutter/services.dart';
 
 class HideableAppBar extends StatefulWidget implements PreferredSizeWidget {
   final Widget title;
@@ -16,6 +12,7 @@ class HideableAppBar extends StatefulWidget implements PreferredSizeWidget {
   HideableAppBar(this.title, this.actions, this.autoHide);
 
   final double defaultHeight = kToolbarHeight; //56.0
+
   @override
   Size get preferredSize => Size.fromHeight(defaultHeight);
   @override

--- a/lib/widgets/HideableControlsPadding.dart
+++ b/lib/widgets/HideableControlsPadding.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
 
 import 'package:LoliSnatcher/ViewerHandler.dart';
@@ -18,7 +17,7 @@ class HideableControlsPadding extends StatefulWidget {
 }
 
 class _HideableControlsPaddingState extends State<HideableControlsPadding> {
-  ViewerHandler viewerHandler = Get.find<ViewerHandler>();
+  final ViewerHandler viewerHandler = Get.find<ViewerHandler>();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/ImagePreviews.dart
+++ b/lib/widgets/ImagePreviews.dart
@@ -1,6 +1,3 @@
-import 'package:LoliSnatcher/ServiceHandler.dart';
-import 'package:LoliSnatcher/widgets/SettingsWidgets.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
@@ -9,15 +6,10 @@ import 'package:LoliSnatcher/SettingsHandler.dart';
 import 'package:LoliSnatcher/libBooru/Booru.dart';
 import 'package:LoliSnatcher/pages/settings/BooruEditPage.dart';
 import 'package:LoliSnatcher/widgets/WaterfallView.dart';
+import 'package:LoliSnatcher/ServiceHandler.dart';
+import 'package:LoliSnatcher/widgets/SettingsWidgets.dart';
 
-class ImagePreviews extends StatefulWidget {
-  ImagePreviews();
-
-  @override
-  _ImagePreviewsState createState() => _ImagePreviewsState();
-}
-
-class _ImagePreviewsState extends State<ImagePreviews> {
+class ImagePreviews extends StatelessWidget {
   final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
   final SearchHandler searchHandler = Get.find<SearchHandler>();
 
@@ -38,7 +30,7 @@ class _ImagePreviewsState extends State<ImagePreviews> {
               SettingsButton(
                 name: 'Add New Booru',
                 icon: Icon(Icons.settings),
-                page: () => BooruEdit(Booru("New","","","",""))
+                page: () => BooruEdit(Booru("New", "", "", "", "")),
               ),
               SettingsButton(
                 name: 'Help',
@@ -46,37 +38,29 @@ class _ImagePreviewsState extends State<ImagePreviews> {
                 action: () {
                   ServiceHandler.launchURL("https://github.com/NO-ob/LoliSnatcher_Droid/wiki");
                 },
-                trailingIcon: Icon(Icons.exit_to_app)
+                trailingIcon: Icon(Icons.exit_to_app),
               ),
-            ]
-          )
+            ],
+          ),
         );
       }
 
       // temp message while restoring tabs (or for some reason initial tab was not created)
-      if(searchHandler.list.isEmpty) {
+      if (searchHandler.list.isEmpty) {
         return Center(
           child: Column(
             children: [
               CircularProgressIndicator(
-                valueColor: AlwaysStoppedAnimation(Get.theme.colorScheme.secondary)
+                valueColor: AlwaysStoppedAnimation(Get.theme.colorScheme.secondary),
               ),
-              if(!searchHandler.isRestored.value)
-                Text('Restoring previous session...'),
+              if (!searchHandler.isRestored.value) Text('Restoring previous session...'),
             ],
-          )
+          ),
         );
       }
 
       // render thumbnails grid
-      return Obx(() => SafeArea(
-        child: WaterfallView(
-          searchHandler.currentTab,
-          searchHandler.index.value
-        )
-      ));
-
+      return WaterfallView(searchHandler.currentTab);
     });
-
-    }
+  }
 }

--- a/lib/widgets/ImageStats.dart
+++ b/lib/widgets/ImageStats.dart
@@ -1,8 +1,7 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:get/get.dart';
+
 import 'package:LoliSnatcher/Tools.dart';
 
 class ImageStats extends StatefulWidget {

--- a/lib/widgets/LoadingElement.dart
+++ b/lib/widgets/LoadingElement.dart
@@ -15,6 +15,7 @@ class LoadingElement extends StatefulWidget {
   final bool isFromCache;
   final bool isDone;
 
+  final bool isTooBig;
   final bool isStopped;
   final List<String> stopReasons;
   final bool isViewed;
@@ -34,6 +35,7 @@ class LoadingElement extends StatefulWidget {
     required this.isFromCache,
     required this.isDone,
 
+    this.isTooBig = false,
     required this.isStopped,
     this.stopReasons = const [],
     required this.isViewed,
@@ -272,7 +274,7 @@ class _LoadingElementState extends State<LoadingElement> {
                       label: BorderedText(
                         strokeWidth: 3,
                         child: Text(
-                          widget.item.isHated.value ? 'Load Anyway' : 'Restart Loading',
+                          (widget.isTooBig || widget.item.isHated.value) ? 'Load Anyway' : 'Restart Loading',
                           style: TextStyle(
                             fontSize: 16,
                             color: Colors.blue,

--- a/lib/widgets/MainAppbar.dart
+++ b/lib/widgets/MainAppbar.dart
@@ -1,0 +1,168 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:LoliSnatcher/SettingsHandler.dart';
+import 'package:LoliSnatcher/SnatchHandler.dart';
+import 'package:LoliSnatcher/ViewerHandler.dart';
+import 'package:LoliSnatcher/getPerms.dart';
+import 'package:LoliSnatcher/widgets/ActiveTitle.dart';
+import 'package:LoliSnatcher/widgets/FlashElements.dart';
+import 'package:LoliSnatcher/widgets/PageNumberDialog.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import 'package:LoliSnatcher/SearchGlobals.dart';
+
+class MainAppBar extends StatefulWidget implements PreferredSizeWidget {
+  final Widget leading;
+  final Widget trailing;
+  MainAppBar({Key? key, required this.leading, required this.trailing}) : super(key: key);
+
+  final double defaultHeight = kToolbarHeight; //56.0
+
+  @override
+  Size get preferredSize => Size.fromHeight(defaultHeight);
+  @override
+  _MainAppBarState createState() => _MainAppBarState();
+}
+
+class _MainAppBarState extends State<MainAppBar> {
+  final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
+  final SearchHandler searchHandler = Get.find<SearchHandler>();
+  final SnatchHandler snatchHandler = Get.find<SnatchHandler>();
+  final ViewerHandler viewerHandler = Get.find<ViewerHandler>();
+
+  double _scrollOffset = 1.0;
+  double _lastScrollPosition = 0.0;
+
+  StreamSubscription<double>? scrollListener;
+  // StreamSubscription<int>? indexListener;
+
+  @override
+  void initState() {
+    super.initState();
+    scrollListener = searchHandler.scrollOffset.listen(updatePosition);
+    // indexListener = searchHandler.index.listen(updateIndex);
+  }
+
+  @override
+  void dispose() {
+    scrollListener?.cancel();
+    // indexListener?.cancel();
+    super.dispose();
+  }
+
+  void updatePosition(double newOffset) {
+    final double prevOffset = _scrollOffset;
+    double scrollChange = ((_lastScrollPosition - newOffset) / searchHandler.gridScrollController.position.viewportDimension) * 10;
+
+    if (newOffset < 0 || (newOffset + 100) > searchHandler.gridScrollController.position.maxScrollExtent) {
+      return;
+    }
+
+    _scrollOffset = max(0, min(1, _scrollOffset + scrollChange));
+    _lastScrollPosition = newOffset;
+
+    if (viewerHandler.inViewer.value) {
+      // always show toolbar when in viewer
+      _scrollOffset = 1.0;
+    }
+
+    if (prevOffset != _scrollOffset) {
+      // print('Scroll Offset: $_scrollOffset');
+      WidgetsBinding.instance?.addPostFrameCallback((_) => setState(() {}));
+    }
+  }
+
+  void updateIndex(int newIndex) {
+    if (searchHandler.gridScrollController.hasClients) {
+      _lastScrollPosition = searchHandler.currentTab.scrollPosition;
+      _scrollOffset = 1.0;
+      updatePosition(_lastScrollPosition);
+    }
+  }
+
+  Widget pageNumberButton() {
+    return IconButton(
+      icon: Icon(Icons.format_list_numbered),
+      onPressed: () {
+        showDialog(
+            context: context,
+            builder: (context) {
+              return PageNumberDialog();
+            });
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedContainer(
+      duration: Duration(milliseconds: 200),
+      curve: Curves.linear,
+      color: Colors.transparent,
+      height: _scrollOffset * (widget.defaultHeight + MediaQuery.of(context).padding.top),
+      child: AppBar(
+        automaticallyImplyLeading: true,
+        leading: widget.leading,
+        title: FittedBox(
+          fit: BoxFit.fitWidth,
+          child: ActiveTitle(),
+        ),
+        actions: [
+          // TODO needs more work and polish
+          pageNumberButton(),
+
+          Obx(() {
+            if (searchHandler.list.isNotEmpty) {
+              return Stack(alignment: Alignment.center, children: [
+                IconButton(
+                  icon: Icon(Icons.save),
+                  onPressed: () {
+                    getPerms();
+                    // call a function to save the currently viewed image when the save button is pressed
+                    if (searchHandler.currentTab.selected.length > 0) {
+                      snatchHandler.queue(
+                        searchHandler.currentTab.getSelected(),
+                        searchHandler.currentTab.selectedBooru.value,
+                        settingsHandler.snatchCooldown,
+                      );
+                      searchHandler.currentTab.selected.value = [];
+                    } else {
+                      FlashElements.showSnackbar(
+                        context: context,
+                        title: Text("No items selected", style: TextStyle(fontSize: 20)),
+                        overrideLeadingIconWidget: Text(" (」°ロ°)」 ", style: TextStyle(fontSize: 18)),
+                      );
+                    }
+                  },
+                ),
+                if (searchHandler.currentTab.selected.isNotEmpty)
+                  Positioned(
+                    child: Container(
+                        width: 20,
+                        height: 20,
+                        decoration: BoxDecoration(
+                          color: Get.theme.colorScheme.secondary,
+                          border: Border.all(color: Get.theme.colorScheme.secondary, width: 1),
+                          borderRadius: BorderRadius.circular(15),
+                        ),
+                        child: Center(
+                            child: FittedBox(
+                          child: Text('${searchHandler.currentTab.selected.length}', style: TextStyle(color: Get.theme.colorScheme.onSecondary)),
+                        ))),
+                    right: 2,
+                    bottom: 5,
+                  ),
+              ]);
+            } else {
+              return const SizedBox.shrink();
+            }
+          }),
+
+          widget.trailing,
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/NotesRenderer.dart
+++ b/lib/widgets/NotesRenderer.dart
@@ -1,0 +1,387 @@
+import 'dart:async';
+// import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import 'package:LoliSnatcher/SearchGlobals.dart';
+import 'package:LoliSnatcher/SettingsHandler.dart';
+import 'package:LoliSnatcher/ViewerHandler.dart';
+import 'package:LoliSnatcher/libBooru/BooruItem.dart';
+import 'package:LoliSnatcher/libBooru/NoteItem.dart';
+import 'package:LoliSnatcher/widgets/FlashElements.dart';
+import 'package:LoliSnatcher/widgets/SettingsWidgets.dart';
+import 'package:LoliSnatcher/utilities/html_parse.dart';
+import 'package:LoliSnatcher/widgets/TransparentPointer.dart';
+
+class NotesRenderer extends StatefulWidget {
+  NotesRenderer({Key? key}) : super(key: key);
+
+  @override
+  _NotesRendererState createState() => _NotesRendererState();
+}
+
+class _NotesRendererState extends State<NotesRenderer> {
+  final SearchHandler searchHandler = Get.find<SearchHandler>();
+  final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
+  final ViewerHandler viewerHandler = Get.find<ViewerHandler>();
+
+  late BooruItem item;
+  late double screenWidth,
+      screenHeight,
+      screenRatio,
+      imageWidth,
+      imageHeight,
+      imageRatio,
+      ratioDiff,
+      widthLimit,
+      viewScale,
+      screenToImageRatio,
+      offsetX,
+      offsetY,
+      viewOffsetX,
+      viewOffsetY;
+  Timer? debounceCalculations;
+  bool loading = false;
+
+  StreamSubscription<BooruItem>? itemListener;
+  StreamSubscription? viewStateListener;
+
+  @override
+  void initState() {
+    super.initState();
+
+    screenWidth = Get.width;
+    screenHeight = Get.height;
+    screenRatio = screenWidth / screenHeight;
+
+    item = searchHandler.viewedItem.value;
+    doCalculations(); // trigger calculations on init even if there is no item to init all values
+    loading = true;
+    loadNotes();
+    itemListener = searchHandler.viewedItem.listen((BooruItem item) {
+      // TODO doesn't trigger for the first item after changing tabs on desktop
+      // print('item changed to $item');
+      this.item = item;
+      loading = true;
+      updateState();
+      loadNotes();
+    });
+
+    viewStateListener = viewerHandler.viewState.listen((viewState) {
+      // TODO when second double tap zoom scale is entered - no state sent?
+      triggerCalculations();
+    });
+  }
+
+  void updateState() {
+    if (this.mounted) {
+      setState(() {});
+    }
+  }
+
+  @override
+  void dispose() {
+    itemListener?.cancel();
+    viewStateListener?.cancel();
+    debounceCalculations?.cancel();
+    super.dispose();
+  }
+
+  void loadNotes() async {
+    final handler = searchHandler.currentBooruHandler;
+    final bool hasSupport = handler.hasNotesSupport;
+    final bool hasNotes = item.hasNotes == true;
+    final bool alreadyLoaded = item.notes.isNotEmpty;
+
+    // print('Loading notes for ${item.fileURL} ${item.notes.length}');
+    // print('hasSupport: $hasSupport hasNotes: $hasNotes alreadyLoaded: $alreadyLoaded');
+
+    if (item.fileURL.isEmpty || !hasSupport || !hasNotes || alreadyLoaded) {
+      loading = false;
+      updateState();
+      return;
+    }
+
+    item.notes.value = await searchHandler.currentBooruHandler.fetchNotes(item.serverId!);
+
+    triggerCalculations();
+
+    loading = false;
+    updateState();
+  }
+
+  void triggerCalculations() {
+    if (debounceCalculations != null && debounceCalculations?.isActive == true) {
+      debounceCalculations!.cancel();
+    }
+    // debounce to prevent unnecessary calculations, especially when resizing
+    // lessens the impact on performance, but causes notes to be a bit shake-ey when resizing
+    debounceCalculations = Timer(Duration(milliseconds: 2), () {
+      doCalculations();
+      updateState();
+    });
+  }
+
+  void doCalculations() {
+    // do the calculations depending on the current item here
+    // print('!!!DOING CALCULATIONS ${Random.secure().nextDouble()}!!!');
+    imageWidth = item.fileWidth ?? 100;
+    imageHeight = item.fileHeight ?? 100;
+    imageRatio = imageWidth / imageHeight;
+
+    ratioDiff = 1;
+    widthLimit = 0;
+    if (settingsHandler.disableImageScaling || item.isNoScale.value) {
+      //  do nothing
+    } else {
+      // image size can change if scaling is allowed and it's size is too big
+      widthLimit = Get.mediaQuery.size.width * Get.mediaQuery.devicePixelRatio * 2;
+      if (imageWidth > widthLimit) {
+        ratioDiff = widthLimit / imageWidth;
+        imageWidth = widthLimit;
+        imageHeight = imageHeight * ratioDiff;
+      }
+    }
+
+    viewScale = viewerHandler.viewState.value.scale ?? 1;
+    screenToImageRatio = viewScale == 1 ? (screenRatio > imageRatio ? (screenWidth / imageWidth) : (screenHeight / imageHeight)) : viewScale;
+
+    offsetX = (screenWidth / 2) - (imageWidth / 2 * screenToImageRatio);
+    offsetY = (screenHeight / 2) - (imageHeight / 2 * screenToImageRatio);
+
+    viewOffsetX = viewerHandler.viewState.value.position.dx;
+    viewOffsetY = viewerHandler.viewState.value.position.dy;
+  }
+
+  Widget buildNote(NoteItem note) {
+    final double scaledX = (note.posX * screenToImageRatio * ratioDiff) + offsetX + viewOffsetX;
+    final double scaledY = (note.posY * screenToImageRatio * ratioDiff) + offsetY + viewOffsetY;
+    final double scaledWidth = note.width * screenToImageRatio * ratioDiff;
+    final double scaledHeight = note.height * screenToImageRatio * ratioDiff;
+
+    // print('sW:$screenWidth sH:$screenHeight iW:$imageWidth iH:$imageHeight iR:$imageRatio');
+    // print('rD:$ratioDiff sTOiR:$screenToImageRatio oX:$offsetX oY:$offsetY t:${note.content}');
+    // print('-------');
+
+    return NoteBuild(
+      text: note.content,
+      left: scaledX,
+      top: scaledY,
+      width: scaledWidth,
+      height: scaledHeight,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(builder: (BuildContext context, BoxConstraints constraints) {
+      if (screenWidth != constraints.maxWidth || screenHeight != constraints.maxHeight) {
+        screenWidth = constraints.maxWidth;
+        screenHeight = constraints.maxHeight;
+        screenRatio = screenWidth / screenHeight;
+        triggerCalculations();
+      }
+
+      return Obx(() {
+        if (!viewerHandler.isLoaded.value || !viewerHandler.showNotes.value || item.fileURL.isEmpty) {
+          return const SizedBox();
+        } else {
+          return Stack(
+            children: [
+              if (loading)
+                Positioned(
+                  left: 60,
+                  top: kToolbarHeight * 1.5,
+                  child: Container(
+                    width: 30,
+                    height: 30,
+                    child: Stack(
+                      alignment: Alignment.center,
+                      children: [
+                        CircularProgressIndicator(
+                          color: Get.theme.colorScheme.secondary,
+                          strokeWidth: 2,
+                        ),
+                        Icon(
+                          Icons.note_add,
+                          size: 18,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ...item.notes.map((note) => buildNote(note)).toList(),
+              // ...List.generate(
+              //   5,
+              //   (int index) => NoteItem(
+              //     postID: 'fakeNote$index',
+              //     content: 'fakeNote$index',
+              //     posX: 100 * index,
+              //     posY: 100 * index,
+              //     width: 100,
+              //     height: 100,
+              //   ),
+              // ).map((note) => buildNote(note)).toList(),
+            ],
+          );
+        }
+      });
+    });
+  }
+}
+
+class NoteBuild extends StatefulWidget {
+  final String? text;
+  final double left;
+  final double top;
+  final double width;
+  final double height;
+  NoteBuild({
+    Key? key,
+    required this.text,
+    required this.left,
+    required this.top,
+    required this.width,
+    required this.height,
+  }) : super(key: key);
+
+  @override
+  _NoteBuildState createState() => _NoteBuildState();
+}
+
+class _NoteBuildState extends State<NoteBuild> {
+  bool isVisible = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      left: widget.left,
+      top: widget.top,
+      child: TransparentPointer(
+        child: GestureDetector(
+          onLongPressStart: (details) {
+            setState(() {
+              isVisible = false;
+            });
+          },
+          onLongPressEnd: (details) {
+            setState(() {
+              isVisible = true;
+            });
+          },
+          onLongPressCancel: () {
+            setState(() {
+              isVisible = true;
+            });
+          },
+          onTap: () {
+            FlashElements.showSnackbar(
+              title: Text('Note'),
+              content: Text.rich(
+                parse(
+                  widget.text ?? '',
+                  TextStyle(
+                    fontSize: 14,
+                  ),
+                  false,
+                ),
+                overflow: TextOverflow.fade,
+              ),
+              duration: null,
+              sideColor: Colors.blue,
+              shouldLeadingPulse: false,
+              asDialog: true,
+            );
+          },
+          behavior: HitTestBehavior.translucent,
+          child: AnimatedOpacity(
+            opacity: isVisible ? 1 : 0,
+            duration: const Duration(milliseconds: 100),
+            child: Container(
+              width: widget.width,
+              height: widget.height,
+              decoration: BoxDecoration(
+                color: Color(0xFFFFF300).withOpacity(0.25),
+                borderRadius: BorderRadius.circular(2),
+                border: Border.all(
+                  color: Color(0xFFFFF176),
+                ),
+              ),
+              child: (widget.width > 30 && widget.height > 30) // don't show if too small
+                  ? Text.rich(
+                      parse(
+                        widget.text ?? '',
+                        TextStyle(
+                          color: Colors.white,
+                          fontSize: 12,
+                        ),
+                        true,
+                      ),
+                      overflow: TextOverflow.fade,
+                    )
+                  : null,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class NotesDialog extends StatelessWidget {
+  final BooruItem item;
+  const NotesDialog(this.item, {Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SettingsDialog(
+      title: Text('Notes'),
+      content: ClipRRect(
+        borderRadius: BorderRadius.circular(6),
+        child: Material(
+          child: Container(
+            width: double.maxFinite,
+            child: ListView.builder(
+              physics: const BouncingScrollPhysics(parent: const AlwaysScrollableScrollPhysics()),
+              itemCount: item.notes.length,
+              itemBuilder: (context, index) {
+                final note = item.notes[index];
+                return ListTile(
+                  title: Text.rich(
+                    parse(
+                      note.content ?? '',
+                      TextStyle(
+                        fontSize: 14,
+                      ),
+                      false,
+                    ),
+                  ),
+                  subtitle: Text('X:${note.posX}/${item.fileWidth!.round()}, Y:${note.posY}/${item.fileHeight!.round()}'),
+                  shape: Border(
+                    bottom: BorderSide(
+                      color: Colors.grey.shade600,
+                      width: 1,
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+      contentPadding: const EdgeInsets.all(12),
+      // titlePadding: const EdgeInsets.fromLTRB(6, 18, 2, 6),
+      // insetPadding: const EdgeInsets.symmetric(horizontal: 0, vertical: 20),
+      scrollable: false,
+      actionButtons: [
+        ElevatedButton(
+          child: Text('Close'),
+          onPressed: () {
+            Navigator.of(context).pop(false);
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/PageNumberDialog.dart
+++ b/lib/widgets/PageNumberDialog.dart
@@ -5,68 +5,57 @@ import 'package:LoliSnatcher/SearchGlobals.dart';
 import 'package:LoliSnatcher/SettingsHandler.dart';
 import 'package:LoliSnatcher/widgets/SettingsWidgets.dart';
 
-class PageNumberDialog extends StatefulWidget {
+class PageNumberDialog extends StatelessWidget {
   PageNumberDialog({Key? key}) : super(key: key);
 
-  @override
-  _PageNumberDialogState createState() => _PageNumberDialogState();
-}
+  final SearchHandler searchHandler = Get.find<SearchHandler>();
+  final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
 
-class _PageNumberDialogState extends State<PageNumberDialog> {
-  SearchHandler searchHandler = Get.find<SearchHandler>();
-  SettingsHandler settingsHandler = Get.find<SettingsHandler>();
-
-  TextEditingController pageNumberController = TextEditingController();
+  final TextEditingController pageNumberController = TextEditingController();
+  final TextEditingController delayController = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
-    pageNumberController.text = searchHandler.currentTab.booruHandler.pageNum.toString();
+    pageNumberController.text = searchHandler.currentBooruHandler.pageNum.toString();
+    delayController.text = 200.toString();
 
-    int total = searchHandler.currentTab.booruHandler.totalCount.value;
-    int possibleMaxPageNum = total != 0 ? (total / settingsHandler.limit).round() : 0;
+    final int total = searchHandler.currentBooruHandler.totalCount.value;
+    final int possibleMaxPageNum = total != 0 ? (total / settingsHandler.limit).round() : 0;
+
     return SettingsDialog(
       contentItems: <Widget>[
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: <Widget>[
-            ElevatedButton(
-              onPressed: () {
-                if(pageNumberController.text.isNotEmpty) {
-                  int newPageNum = int.parse(pageNumberController.text) - 1;
-                  if(newPageNum > -2) pageNumberController.text = newPageNum.toString();
-                }
-              },
-              child: Icon(Icons.exposure_minus_1),
-            ),
-            const SizedBox(width: 5),
-            Expanded(child: Container(
-              margin: const EdgeInsets.symmetric(vertical: 20),
-              child: SettingsTextInput(
-                title: "Page #",
-                hintText: "Page #",
-                onlyInput: true,
-                controller: pageNumberController,
-                autofocus: false,
-                inputType: TextInputType.numberWithOptions(signed: false, decimal: false),
-                onSubmitted: (String text) {
-
-                },
-              )
-            )),
-            const SizedBox(width: 5),
-            ElevatedButton(
-              onPressed: () {
-                if(pageNumberController.text.isNotEmpty) {
-                  int newPageNum = int.parse(pageNumberController.text) + 1;
-                  pageNumberController.text = newPageNum.toString();
-                }
-              },
-              child: Icon(Icons.exposure_plus_1),
-            ),
-          ],
+        SettingsTextInput(
+          title: "Page #",
+          hintText: "Page #",
+          onlyInput: true,
+          controller: pageNumberController,
+          autofocus: true,
+          inputType: TextInputType.numberWithOptions(signed: false, decimal: false),
+          numberButtons: true,
+          numberStep: 1,
+          numberMin: -1,
+          numberMax: double.infinity,
         ),
-        SettingsButton(name: 'Current page #${searchHandler.currentTab.booruHandler.pageNum.value}', drawTopBorder: true),
-        if(possibleMaxPageNum != 0)
+        SettingsTextInput(
+          title: "Delay between loadings",
+          hintText: "Delay in ms",
+          onlyInput: true,
+          controller: delayController,
+          autofocus: false,
+          inputType: TextInputType.numberWithOptions(signed: false, decimal: false),
+          numberButtons: true,
+          numberStep: 100,
+          numberMin: 0,
+          numberMax: 10000,
+        ),
+        SettingsButton(
+          name: 'Current page #${searchHandler.currentBooruHandler.pageNum.value}',
+          action: () {
+            pageNumberController.text = searchHandler.currentBooruHandler.pageNum.value.toString();
+          },
+          drawTopBorder: true,
+        ),
+        if (possibleMaxPageNum != 0)
           SettingsButton(
             name: 'Possible max page #~$possibleMaxPageNum',
             action: () {
@@ -76,21 +65,19 @@ class _PageNumberDialogState extends State<PageNumberDialog> {
       ],
       actionButtons: <Widget>[
         ElevatedButton(
-          child: Text('Start from page'),
+          child: Text('Jump to page'),
           onPressed: () {
-            if(pageNumberController.text.isNotEmpty) {
-              searchHandler.changeCurrentTabPageNumber(int.parse(pageNumberController.text) - 1);
-              setState(() { });
+            if (pageNumberController.text.isNotEmpty) {
+              searchHandler.changeCurrentTabPageNumber((int.tryParse(pageNumberController.text) ?? 0) - 1);
               Navigator.of(context).pop();
             }
           },
         ),
         ElevatedButton(
-          child: Text('Search to page'),
+          child: Text('Search until page'),
           onPressed: () {
-            if(pageNumberController.text.isNotEmpty) {
-              searchHandler.searchCurrentTabUntilPageNumber(int.parse(pageNumberController.text) - 1);
-              setState(() { });
+            if (pageNumberController.text.isNotEmpty) {
+              searchHandler.searchCurrentTabUntilPageNumber((int.tryParse(pageNumberController.text) ?? 0) - 1, customDelay: (int.tryParse(delayController.text) ?? 200));
               Navigator.of(context).pop();
             }
           },

--- a/lib/widgets/ResizableSplitView.dart
+++ b/lib/widgets/ResizableSplitView.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+
+enum SplitDirection {
+  horizontal,
+  vertical,
+}
+
+class ResizableSplitView extends StatefulWidget {
+  final Widget firstChild;
+  final Widget secondChild;
+  final double startRatio;
+  final double minRatio;
+  final double maxRatio;
+  final SplitDirection direction;
+  final Function(double)? onRatioChange; 
+
+  const ResizableSplitView({
+    Key? key,
+    required this.firstChild,
+    required this.secondChild,
+    this.startRatio = 0.5,
+    this.minRatio = 0.2,
+    this.maxRatio = 1,
+    this.direction = SplitDirection.horizontal,
+    this.onRatioChange,
+  })  : assert(startRatio >= 0),
+        assert(startRatio <= 1),
+        assert(minRatio >= 0),
+        assert(minRatio <= 1),
+        super(key: key);
+
+  @override
+  _ResizableSplitViewState createState() => _ResizableSplitViewState();
+}
+
+class _ResizableSplitViewState extends State<ResizableSplitView> {
+  final _dividerWidth = 16.0;
+
+  late double _ratio;
+  double? _maxSize;
+
+  get _size1 => _ratio * _maxSize!;
+
+  get _size2 => (1 - _ratio) * _maxSize!;
+
+  @override
+  void initState() {
+    super.initState();
+    _ratio = widget.startRatio;
+  }
+
+  Widget directionWidget({List<Widget> children = const []}) {
+    if (widget.direction == SplitDirection.horizontal) {
+      return Row(
+        children: children,
+      );
+    } else {
+      return Column(
+        children: children,
+      );
+    }
+  }
+
+  void updateRatio(DragUpdateDetails details) {
+    if (widget.direction == SplitDirection.horizontal) {
+      _ratio += details.delta.dx / _maxSize!;
+    } else {
+      _ratio += details.delta.dy / _maxSize!;
+    }
+
+    if (_ratio > widget.maxRatio) {
+      _ratio = widget.maxRatio;
+    } else if (_ratio < widget.minRatio) {
+      _ratio = widget.minRatio;
+    }
+
+    widget.onRatioChange?.call(_ratio);
+
+    if (this.mounted) setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(builder: (context, BoxConstraints constraints) {
+      assert(_ratio <= 1);
+      assert(_ratio >= 0);
+      final double directionSize = widget.direction == SplitDirection.horizontal ? constraints.maxWidth : constraints.maxHeight;
+      if (_maxSize == null) _maxSize = directionSize - _dividerWidth;
+      if (_maxSize != directionSize) {
+        _maxSize = directionSize - _dividerWidth;
+      }
+
+      return SizedBox(
+        width: widget.direction == SplitDirection.horizontal ? constraints.maxWidth : null,
+        height: widget.direction == SplitDirection.horizontal ? null : constraints.maxHeight,
+        child: directionWidget(
+          children: <Widget>[
+            SizedBox(
+              width: widget.direction == SplitDirection.horizontal ? _size1 : null,
+              height: widget.direction == SplitDirection.horizontal ? null : _size1,
+              child: widget.firstChild,
+            ),
+            MouseRegion(
+              cursor: SystemMouseCursors.grab,
+              child: GestureDetector(
+                behavior: HitTestBehavior.translucent,
+                child: SizedBox(
+                  width: widget.direction == SplitDirection.horizontal ? _dividerWidth : constraints.maxWidth,
+                  height: widget.direction == SplitDirection.horizontal ? constraints.maxHeight : _dividerWidth,
+                  child: RotationTransition(
+                    child: Icon(Icons.drag_handle),
+                    turns: widget.direction == SplitDirection.horizontal ? AlwaysStoppedAnimation(0.25) : AlwaysStoppedAnimation(0.50),
+                  ),
+                ),
+                onPanUpdate: updateRatio,
+              ),
+            ),
+            SizedBox(
+              width: widget.direction == SplitDirection.horizontal ? _size2 : null,
+              height: widget.direction == SplitDirection.horizontal ? null : _size2,
+              child: widget.secondChild,
+            ),
+          ],
+        ),
+      );
+    });
+  }
+}

--- a/lib/widgets/StaggeredBuilder.dart
+++ b/lib/widgets/StaggeredBuilder.dart
@@ -1,0 +1,131 @@
+import 'dart:math';
+
+import 'package:LoliSnatcher/SearchGlobals.dart';
+import 'package:LoliSnatcher/SettingsHandler.dart';
+import 'package:LoliSnatcher/widgets/ThumbCardBuild.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
+import 'package:get/get.dart';
+import 'package:waterfall_flow/waterfall_flow.dart';
+
+class StaggeredBuilder extends StatelessWidget {
+  final onTap;
+  StaggeredBuilder(this.onTap, {Key? key}) : super(key: key);
+
+  final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
+  final SearchHandler searchHandler = Get.find<SearchHandler>();
+
+  @override
+  Widget build(BuildContext context) {
+    int columnCount =
+      (MediaQuery.of(context).orientation == Orientation.portrait)
+          ? settingsHandler.portraitColumns
+          : settingsHandler.landscapeColumns;
+
+    bool isDesktop = settingsHandler.appMode == 'Desktop';
+      
+    return LayoutBuilder(builder: (ctx, constraints) {
+      double itemMaxWidth = constraints.maxWidth / columnCount; //MediaQuery.of(context).size.width / columnCount;
+      double itemMaxHeight = itemMaxWidth * (16 / 9); //MediaQuery.of(context).size.height * 0.6;
+      return Obx(() {
+        return WaterfallFlow.builder(
+          controller: searchHandler.gridScrollController,
+          physics: const BouncingScrollPhysics(parent: const AlwaysScrollableScrollPhysics()),
+          shrinkWrap: false,
+          addAutomaticKeepAlives: false,
+          cacheExtent: 200,
+          itemCount: searchHandler.currentFetched.length,
+          padding: EdgeInsets.fromLTRB(2, 2 + (isDesktop ? 0 : (kToolbarHeight + MediaQuery.of(context).padding.top)), 2, 80),
+          gridDelegate: SliverWaterfallFlowDelegateWithFixedCrossAxisCount(
+            crossAxisCount: columnCount,
+            mainAxisSpacing: 4.0,
+            crossAxisSpacing: 4.0,
+          ),
+          itemBuilder: (BuildContext context, int index) {
+            double? widthData = searchHandler.currentFetched[index].fileWidth ?? null;
+            double? heightData = searchHandler.currentFetched[index].fileHeight ?? null;
+            
+            double possibleWidth = itemMaxWidth;
+            double possibleHeight = itemMaxWidth;
+            bool hasSizeData = heightData != null && widthData != null;
+            if(hasSizeData) {
+              double aspectRatio = widthData / heightData;
+              possibleHeight = possibleWidth / aspectRatio;
+            }
+            // force to use minimum 100 px and max 60% of screen height
+            possibleHeight = max(min(itemMaxHeight, possibleHeight), 100);
+            
+            return Container(
+              height: possibleHeight,
+              width: possibleWidth,
+              // constraints: hasSizeData
+              //     ? BoxConstraints(minHeight: possibleHeight, maxHeight: possibleHeight, minWidth: possibleWidth, maxWidth: possibleWidth)
+              //     : BoxConstraints(minHeight: possibleWidth, maxHeight: double.infinity, minWidth: possibleWidth, maxWidth: possibleWidth),
+              child: ThumbCardBuild(index, columnCount, onTap, searchHandler.currentTab),
+            );
+          },
+        );
+      });
+    });
+  }
+}
+
+
+class StaggeredBuilderOld extends StatelessWidget {
+  final onTap;
+  StaggeredBuilderOld(this.onTap, {Key? key}) : super(key: key);
+
+  final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
+  final SearchHandler searchHandler = Get.find<SearchHandler>();
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO flutter upgrade to 2.0.6 seems to prevent memory overflow and stutter on new images a little, but it still won't unload things that are not in view
+    return Obx(() {
+      int columnCount =
+        (MediaQuery.of(context).orientation == Orientation.portrait)
+            ? settingsHandler.portraitColumns
+            : settingsHandler.landscapeColumns;
+      double itemMaxWidth = MediaQuery.of(context).size.width / columnCount;
+      double itemMaxHeight = MediaQuery.of(context).size.height * 0.6;
+
+      bool isDesktop = settingsHandler.appMode == 'Desktop';
+
+      return StaggeredGridView.countBuilder(
+        controller: searchHandler.gridScrollController,
+        physics: const BouncingScrollPhysics(parent: const AlwaysScrollableScrollPhysics()),
+        addAutomaticKeepAlives: false,
+        shrinkWrap: false,
+        itemCount: searchHandler.currentFetched.length,
+        padding: EdgeInsets.fromLTRB(2, 2 + (isDesktop ? 0 : (kToolbarHeight + MediaQuery.of(context).padding.top)), 2, 80),
+        crossAxisCount: columnCount,
+        itemBuilder: (BuildContext context, int index) {
+          double? widthData = searchHandler.currentFetched[index].fileWidth ?? null;
+          double? heightData = searchHandler.currentFetched[index].fileHeight ?? null;
+          
+          double possibleWidth = itemMaxWidth;
+          double possibleHeight = itemMaxWidth;
+          bool hasSizeData = heightData != null && widthData != null;
+          if(hasSizeData) {
+            double aspectRatio = widthData / heightData;
+            possibleHeight = possibleWidth / aspectRatio;
+          }
+          // force to use minimum 100 px and max 60% of screen height
+          possibleHeight = max(min(itemMaxHeight, possibleHeight), 100);
+          
+          return Container(
+            height: possibleHeight,
+            width: possibleWidth,
+            // constraints: hasSizeData
+            //     ? BoxConstraints(minHeight: possibleHeight, maxHeight: possibleHeight, minWidth: possibleWidth, maxWidth: possibleWidth)
+            //     : BoxConstraints(minHeight: possibleWidth, maxHeight: double.infinity, minWidth: possibleWidth, maxWidth: possibleWidth),
+            child: ThumbCardBuild(index, columnCount, onTap, searchHandler.currentTab),
+          );
+        },
+        staggeredTileBuilder: (int index) => StaggeredTile.fit(1),
+        mainAxisSpacing: 4.0,
+        crossAxisSpacing: 4.0,
+      );
+    });
+  }
+}

--- a/lib/widgets/TabBox.dart
+++ b/lib/widgets/TabBox.dart
@@ -7,13 +7,7 @@ import 'package:LoliSnatcher/widgets/MarqueeText.dart';
 import 'package:LoliSnatcher/SettingsHandler.dart';
 import 'package:LoliSnatcher/widgets/CachedFavicon.dart';
 
-class TabBox extends StatefulWidget {
-  TabBox();
-  @override
-  _TabBoxState createState() => _TabBoxState();
-}
-
-class _TabBoxState extends State<TabBox> {
+class TabBox extends StatelessWidget {
   final SearchHandler searchHandler = Get.find<SearchHandler>();
   final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
 
@@ -50,22 +44,22 @@ class _TabBoxState extends State<TabBox> {
       width: double.maxFinite,
       height: 30,
       child: Row(
-      children: [
-        isNotEmptyBooru
-          ? (tab.selectedBooru.value.type == "Favourites"
-            ? Icon(Icons.favorite, color: Colors.red, size: 18)
-            : CachedFavicon(tab.selectedBooru.value.faviconURL!)
-          )
-          : Icon(CupertinoIcons.question, size: 18),
-        const SizedBox(width: 3),
-        MarqueeText(
-          key: ValueKey(tagText),
-          text: tagText,
-          fontSize: 16,
-          color: tab.tags == "" ? Colors.grey : null,
-        ),
-      ]
-    )
+        children: [
+          isNotEmptyBooru
+            ? (tab.selectedBooru.value.type == "Favourites"
+              ? Icon(Icons.favorite, color: Colors.red, size: 18)
+              : CachedFavicon(tab.selectedBooru.value.faviconURL!)
+            )
+            : Icon(CupertinoIcons.question, size: 18),
+          const SizedBox(width: 3),
+          MarqueeText(
+            key: ValueKey(tagText),
+            text: tagText,
+            fontSize: 16,
+            color: tab.tags == "" ? Colors.grey : null,
+          ),
+        ]
+      )
     );
   }
 
@@ -76,7 +70,7 @@ class _TabBoxState extends State<TabBox> {
       padding: settingsHandler.appMode == 'Desktop' ? EdgeInsets.fromLTRB(2, 5, 2, 2) : EdgeInsets.fromLTRB(5, 8, 5, 8),
       child: Obx(() {
         List<SearchGlobal> list = searchHandler.list;
-        int index = searchHandler.index.value;
+        int index = searchHandler.currentIndex;
 
         if(list.length == 0) {
           return const SizedBox();
@@ -89,6 +83,7 @@ class _TabBoxState extends State<TabBox> {
             isExpanded: true,
             value: list[index],
             icon: Icon(Icons.arrow_drop_down),
+            itemHeight: kMinInteractiveDimension,
             decoration: InputDecoration(
               labelText: 'Tab',
               labelStyle: TextStyle(color: Get.theme.colorScheme.onBackground, fontSize: 18),

--- a/lib/widgets/TabBoxButtons.dart
+++ b/lib/widgets/TabBoxButtons.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
@@ -6,26 +5,21 @@ import 'package:LoliSnatcher/SearchGlobals.dart';
 import 'package:LoliSnatcher/SettingsHandler.dart';
 import 'package:LoliSnatcher/widgets/HistoryList.dart';
 
-class TabBoxButtons extends StatefulWidget {
+class TabBoxButtons extends StatelessWidget {
   final bool withSecondary;
   final MainAxisAlignment? alignment;
   TabBoxButtons(this.withSecondary, this.alignment);
 
-  @override
-  _TabBoxButtonsState createState() => _TabBoxButtonsState();
-}
-
-class _TabBoxButtonsState extends State<TabBoxButtons> {
   final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
   final SearchHandler searchHandler = Get.find<SearchHandler>();
 
-  void showHistory() async {
-    showDialog(
+  Future<bool> showHistory(BuildContext context) async {
+    return await showDialog(
       context: context,
       builder: (context) {
         return HistoryList();
       }
-    );
+    ) ?? false;
   }
 
   @override
@@ -37,20 +31,20 @@ class _TabBoxButtonsState extends State<TabBoxButtons> {
       }
 
       return Row(
-        mainAxisAlignment: widget.alignment ?? MainAxisAlignment.spaceEvenly,
+        mainAxisAlignment: alignment ?? MainAxisAlignment.spaceEvenly,
         mainAxisSize: MainAxisSize.max,
         children: [
           const SizedBox(width: 25),
 
-          if(widget.withSecondary)
+          if(withSecondary)
             IconButton(
               icon: Icon(Icons.arrow_upward, color: Get.theme.colorScheme.secondary),
               onPressed: () {
                 // switch to the prev tab, loop if reached the first
-                if((searchHandler.index.value - 1) < 0) {
+                if((searchHandler.currentIndex - 1) < 0) {
                   searchHandler.changeTabIndex(searchHandler.list.length - 1);
                 } else {
-                  searchHandler.changeTabIndex(searchHandler.index.value - 1);
+                  searchHandler.changeTabIndex(searchHandler.currentIndex - 1);
                 }
               },
             ),
@@ -59,14 +53,14 @@ class _TabBoxButtonsState extends State<TabBoxButtons> {
             icon: Icon(Icons.remove_circle_outline, color: Get.theme.colorScheme.secondary),
             onPressed: () {
               // Remove selected searchglobal from list and apply nearest to search bar
-              searchHandler.removeAt();
+              searchHandler.removeTabAt();
             },
           ),
 
           IconButton(
             icon: Icon(Icons.history, color: Get.theme.colorScheme.secondary),
             onPressed: () async {
-              showHistory();
+              await showHistory(context);
             },
           ),
 
@@ -82,15 +76,15 @@ class _TabBoxButtonsState extends State<TabBoxButtons> {
             },
           ),
 
-          if(widget.withSecondary)
+          if(withSecondary)
             IconButton(
               icon: Icon(Icons.arrow_downward, color: Get.theme.colorScheme.secondary),
               onPressed: () {
                 // switch to the next tab, loop if reached the last
-                if((searchHandler.index.value + 1) > (searchHandler.list.length - 1)) {
+                if((searchHandler.currentIndex + 1) > (searchHandler.list.length - 1)) {
                   searchHandler.changeTabIndex(0);
                 } else {
-                  searchHandler.changeTabIndex(searchHandler.index.value + 1);
+                  searchHandler.changeTabIndex(searchHandler.currentIndex + 1);
                 }
               },
             ),

--- a/lib/widgets/TagSearchBox.dart
+++ b/lib/widgets/TagSearchBox.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:ui';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -325,7 +324,7 @@ class _TagSearchBoxState extends State<TagSearchBox> {
 
   void searchBooru(String input) async {
     booruResults.value = [[' ', 'loading']];
-    List<String?>? getFromBooru = await searchHandler.currentTab.booruHandler.tagSearch(lastTag);
+    List<String?>? getFromBooru = await searchHandler.currentBooruHandler.tagSearch(lastTag);
     booruResults.value = getFromBooru?.map((tag){
       final String tagTemp = tag != null ? tag : '';
       return [tagTemp, 'booru'];
@@ -359,7 +358,7 @@ class _TagSearchBoxState extends State<TagSearchBox> {
   }
 
   Future<List<List<String>?>> combinedSearchOld(String input) async {
-    List<String?>? getFromBooru = await searchHandler.currentTab.booruHandler.tagSearch(lastTag);
+    List<String?>? getFromBooru = await searchHandler.currentBooruHandler.tagSearch(lastTag);
     final List<List<String>> booruResults = getFromBooru?.map((tag){
       final String tagTemp = tag != null ? tag : '';
       return [tagTemp, 'booru'];
@@ -558,6 +557,7 @@ class _TagSearchBoxState extends State<TagSearchBox> {
                     padding: const EdgeInsets.all(5),
                     onPressed: () {
                       searchHandler.searchTextController.clear();
+                      tagStuff();
                       setState(() {});
                     },
                     icon: Icon(Icons.clear, color: Get.theme.colorScheme.onBackground),
@@ -596,7 +596,7 @@ class _TagSearchBoxState extends State<TagSearchBox> {
                       ),
                     )
                   ),
-              contentPadding: EdgeInsets.fromLTRB(15, 0, 10, 0), // left,top,right,bottom
+              contentPadding: EdgeInsets.fromLTRB(15, 0, 5, 0), // left,top,right,bottom
               focusedBorder: OutlineInputBorder(
                 borderSide: BorderSide(color: Get.theme.colorScheme.secondary),
                 borderRadius: BorderRadius.circular(50),

--- a/lib/widgets/TagSearchButton.dart
+++ b/lib/widgets/TagSearchButton.dart
@@ -2,14 +2,9 @@ import 'package:LoliSnatcher/SearchGlobals.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-class TagSearchButton extends StatefulWidget {
+class TagSearchButton extends StatelessWidget {
   TagSearchButton({Key? key}) : super(key: key);
 
-  @override
-  _TagSearchButtonState createState() => _TagSearchButtonState();
-}
-
-class _TagSearchButtonState extends State<TagSearchButton> {
   final SearchHandler searchHandler = Get.find<SearchHandler>();
 
   @override
@@ -27,13 +22,13 @@ class _TagSearchButtonState extends State<TagSearchButton> {
       },
       child: IconButton(
         iconSize: 30,
-        icon: Icon(Icons.search),
+        icon: Icon(Icons.search, color: Get.theme.colorScheme.onSurface),
         onPressed: () {
-        searchHandler.searchTextController.clearComposing();
-        searchHandler.searchBoxFocus.unfocus();
-        searchHandler.searchAction(searchHandler.searchTextController.text, null);
-      },
-      )
+          searchHandler.searchTextController.clearComposing();
+          searchHandler.searchBoxFocus.unfocus();
+          searchHandler.searchAction(searchHandler.searchTextController.text, null);
+        },
+      ),
     );
   }
 }

--- a/lib/widgets/ThumbBuild.dart
+++ b/lib/widgets/ThumbBuild.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import 'package:LoliSnatcher/SearchGlobals.dart';
+import 'package:LoliSnatcher/SettingsHandler.dart';
+import 'package:LoliSnatcher/ViewUtils.dart';
+import 'package:LoliSnatcher/libBooru/BooruItem.dart';
+import 'package:LoliSnatcher/widgets/CachedThumbBetter.dart';
+
+class ThumbBuild extends StatelessWidget {
+  final int index;
+  final int columnCount;
+  final SearchGlobal searchGlobal;
+
+  ThumbBuild(this.index, this.columnCount, this.searchGlobal, {Key? key}) : super(key: key);
+
+  final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
+
+  @override
+  Widget build(BuildContext context) {
+    BooruItem item = searchGlobal.booruHandler.filteredFetched[index];
+    IconData itemIcon = ViewUtils.getFileIcon(item.mediaType);
+
+    List<List<String>> parsedTags = settingsHandler.parseTagsList(item.tagsList, isCapped: false);
+    bool isHated = parsedTags[0].length > 0;
+    bool isLoved = parsedTags[1].length > 0;
+    bool isSound = parsedTags[2].length > 0;
+    bool isNoted = item.hasNotes == true;
+    
+    // reset the isHated value since we already check for it on every render
+    item.isHated.value = isHated;
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(3),
+      child: Stack(
+        alignment: settingsHandler.previewDisplay == "Square" ? Alignment.center : Alignment.bottomCenter,
+        children: [
+          CachedThumbBetter(item, index, searchGlobal, columnCount, true),
+          // Image(
+          //   image: ResizeImage(NetworkImage(item.thumbnailURL), width: (MediaQuery.of(context).size.width * MediaQuery.of(context).devicePixelRatio / 3).round()),
+          //   fit: BoxFit.cover,
+          //   isAntiAlias: true,
+          //   filterQuality: FilterQuality.medium,
+          //   width: double.infinity,
+          //   height: double.infinity,
+          // ),
+          Container(
+            alignment: Alignment.bottomCenter,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                // reserved for elements on the left side
+                const SizedBox(),
+
+                Container(
+                  padding: EdgeInsets.all(3),
+                  decoration: BoxDecoration(
+                    color: Colors.black.withOpacity(0.66),
+                    borderRadius: BorderRadius.only(topLeft: Radius.circular(5))
+                  ),
+                  child: Obx(() =>  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      // Text('  ${(index + 1)}  ', style: TextStyle(fontSize: 10, color: Colors.white)),
+
+                      if(item.isFavourite.value == null)
+                        Text('.'),
+
+                      AnimatedCrossFade(
+                        duration: Duration(milliseconds: 200),
+                        crossFadeState: (item.isFavourite.value == true || isLoved) ? CrossFadeState.showFirst : CrossFadeState.showSecond,
+                        firstChild: AnimatedSwitcher(
+                          duration: Duration(milliseconds: 200),
+                          child: Icon(
+                            item.isFavourite.value == true ? Icons.favorite : Icons.star,
+                            color: item.isFavourite.value == true ? Colors.red : Colors.grey,
+                            key: ValueKey<Color>(item.isFavourite.value == true ? Colors.red : Colors.grey),
+                            size: 14,
+                          )
+                        ),
+                        secondChild: const SizedBox(),
+                      ),
+
+                      if(item.isSnatched.value == true)
+                        Icon(
+                          Icons.save_alt,
+                          color: Colors.white,
+                          size: 14,
+                        ),
+
+                      if(isSound)
+                        Icon(
+                          Icons.volume_up_rounded,
+                          color: Colors.white,
+                          size: 14,
+                        ),
+
+                      if(isNoted)
+                        Icon(
+                          Icons.note_add,
+                          color: Colors.white,
+                          size: 14,
+                        ),
+
+                      Icon(
+                        itemIcon,
+                        color: Colors.white,
+                        size: 14,
+                      ),
+                    ],
+                  )),
+                ),
+              ]
+            )
+          )
+        ]
+      )
+    );
+  }
+}

--- a/lib/widgets/ThumbCardBuild.dart
+++ b/lib/widgets/ThumbCardBuild.dart
@@ -1,0 +1,108 @@
+import 'package:LoliSnatcher/SearchGlobals.dart';
+import 'package:LoliSnatcher/ServiceHandler.dart';
+import 'package:LoliSnatcher/SettingsHandler.dart';
+import 'package:LoliSnatcher/libBooru/BooruItem.dart';
+import 'package:LoliSnatcher/widgets/FlashElements.dart';
+import 'package:LoliSnatcher/widgets/ThumbBuild.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:get/get.dart';
+import 'package:scroll_to_index/scroll_to_index.dart';
+
+class ThumbCardBuild extends StatelessWidget {
+  final int index;
+  final int columnCount;
+  final SearchGlobal tab;
+  final Function(int) onTap;
+  ThumbCardBuild(this.index, this.columnCount, this.onTap, this.tab, {Key? key}) : super(key: key);
+
+  final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
+  final SearchHandler searchHandler = Get.find<SearchHandler>();
+
+  void onDoubleTap(int index) async {
+    BooruItem item = tab.booruHandler.filteredFetched[index];
+    if(item.isFavourite.value != null) {
+      ServiceHandler.vibrate();
+
+      item.isFavourite.toggle();
+      settingsHandler.dbHandler.updateBooruItem(item, "local");
+    }
+  }
+
+  void onLongPress(int index) async {
+    ServiceHandler.vibrate(duration: 5);
+
+    if (tab.selected.contains(index)) {
+      tab.selected.remove(index);
+    } else {
+      tab.selected.add(index);
+    }
+  }
+
+  void onSecondaryTap(int index) {
+    BooruItem item = tab.booruHandler.filteredFetched[index];
+    Clipboard.setData(ClipboardData(text: item.fileURL));
+    FlashElements.showSnackbar(
+      duration: Duration(seconds: 2),
+      title: Text(
+        "Copied File URL to clipboard!",
+        style: TextStyle(fontSize: 20)
+      ),
+      content: Text(
+        item.fileURL,
+        style: TextStyle(fontSize: 16)
+      ),
+      leadingIcon: Icons.copy,
+      sideColor: Colors.green,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Obx(() {
+      bool isSelected = tab.selected.contains(index);
+      bool isCurrent = settingsHandler.appMode == 'Desktop' && (searchHandler.viewedIndex.value == index);
+
+      return AutoScrollTag(
+        highlightColor: Colors.red,
+        key: ValueKey(index),
+        controller: searchHandler.gridScrollController,
+        index: index,
+        child: Material(
+          borderOnForeground: true,
+          child: Ink(
+            decoration: (isCurrent || isSelected)
+              ? BoxDecoration(
+                border: Border.all(
+                  color: isCurrent ? Colors.red : Get.theme.colorScheme.secondary,
+                  width: 2.0,
+                ),
+              )
+              : null,
+            child: GestureDetector(
+              onSecondaryTap: () {
+                onSecondaryTap(index);
+              },
+              child: InkResponse(
+                enableFeedback: true,
+                highlightShape: BoxShape.rectangle,
+                containedInkWell: false,
+                highlightColor: Get.theme.colorScheme.secondary,
+                child: ThumbBuild(index, columnCount, tab),
+                onTap: () {
+                  onTap(index);
+                },
+                onDoubleTap: () {
+                  onDoubleTap(index);
+                },
+                onLongPress: () {
+                  onLongPress(index);
+                },
+              ),
+            ),
+          ),
+        )
+      );
+    });
+  }
+}

--- a/lib/widgets/TransparentPointer.dart
+++ b/lib/widgets/TransparentPointer.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+// Code from: https://github.com/spkersten/flutter_transparent_pointer/blob/null-safety
+
+/// This widget is invisible for its parent to hit testing, but still
+/// allows its subtree to receive pointer events.
+///
+/// {@tool snippet}
+///
+/// In this example, a drag can be started anywhere in the widget, including on
+/// top of the text button, even though the button is visually in front of the
+/// background gesture detector. At the same time, the button is tappable.
+///
+/// ```dart
+/// class MyWidget extends StatelessWidget {
+///   @override
+///   Widget build(BuildContext context) {
+///     return Stack(
+///       children: [
+///         GestureDetector(
+///           behavior: HitTestBehavior.opaque,
+///           onVerticalDragStart: (_) => print("Background drag started"),
+///         ),
+///         Positioned(
+///           top: 60,
+///           left: 60,
+///           height: 60,
+///           width: 60,
+///           child: TransparentPointer(
+///             child: TextButton(
+///               child: Text("Tap me"),
+///               onPressed: () => print("You tapped me"),
+///             ),
+///           ),
+///         ),
+///       ],
+///     );
+///   }
+/// }
+/// ```
+/// {@end-tool}
+///
+/// See also:
+///
+///  * [IgnorePointer], which is also invisible for its parent during hit testing, but
+///    does not allow its subtree to receive pointer events.
+///  * [AbsorbPointer], which is visible during hit testing, but prevents its subtree
+///    from receiving pointer event. The opposite of this widget.
+class TransparentPointer extends SingleChildRenderObjectWidget {
+  /// Creates a widget that is invisible for its parent to hit testing, but still
+  /// allows its subtree to receive pointer events.
+  const TransparentPointer({
+    Key? key,
+    this.transparent = true,
+    required Widget child,
+  })  : super(key: key, child: child);
+
+  /// Whether this widget is invisible to its parent during hit testing.
+  final bool transparent;
+
+  @override
+  RenderTransparentPointer createRenderObject(BuildContext context) {
+    return RenderTransparentPointer(
+      transparent: transparent,
+    );
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, RenderTransparentPointer renderObject) {
+    renderObject..transparent = transparent;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<bool>('transparent', transparent));
+  }
+}
+
+class RenderTransparentPointer extends RenderProxyBox {
+  RenderTransparentPointer({
+    RenderBox? child,
+    bool transparent = true,
+  })  : _transparent = transparent,
+        super(child);
+
+  bool get transparent => _transparent;
+  bool _transparent;
+
+  set transparent(bool value) {
+    if (value == _transparent) return;
+    _transparent = value;
+  }
+
+  @override
+  bool hitTest(BoxHitTestResult result, {required Offset position}) {
+    final hit = super.hitTest(result, position: position);
+    return !transparent && hit;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<bool>('transparent', transparent));
+  }
+}

--- a/lib/widgets/VideoAppDesktop.dart
+++ b/lib/widgets/VideoAppDesktop.dart
@@ -5,11 +5,11 @@ import 'dart:async';
 import 'package:dio/dio.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:dart_vlc/dart_vlc.dart';
 
+import 'package:LoliSnatcher/Tools.dart';
 import 'package:LoliSnatcher/ViewUtils.dart';
 import 'package:LoliSnatcher/widgets/CachedThumbBetter.dart';
 import 'package:LoliSnatcher/widgets/DioDownloader.dart';
@@ -40,8 +40,11 @@ class _VideoAppDesktopState extends State<VideoAppDesktop> {
 
   RxInt _total = 0.obs, _received = 0.obs, _startedAt = 0.obs;
   int _lastViewedIndex = -1;
-  bool isFromCache = false, isStopped = false, firstViewFix = false, isZoomed = false, isLoaded = false;
+  int isTooBig = 0; // 0 = not too big, 1 = too big, 2 = too big, but allow downloading
+  bool isFromCache = false, isStopped = false, firstViewFix = false, isViewed = false, isZoomed = false, isLoaded = false;
   List<String> stopReason = [];
+
+  StreamSubscription? indexListener;
 
   CancelToken? _dioCancelToken;
   DioLoader? client;
@@ -82,6 +85,7 @@ class _VideoAppDesktopState extends State<VideoAppDesktop> {
     if(!settingsHandler.mediaCache) {
       // Media caching disabled - don't cache videos
       initPlayer();
+      getSize();
       return;
     }
     switch (settingsHandler.videoCacheMode) {
@@ -99,6 +103,7 @@ class _VideoAppDesktopState extends State<VideoAppDesktop> {
       default:
         // Only stream, notice the return
         initPlayer();
+        getSize();
         return;
     }
 
@@ -130,22 +135,52 @@ class _VideoAppDesktopState extends State<VideoAppDesktop> {
     return;
   }
 
+  Future<void> getSize() async {
+    _dioCancelToken = CancelToken();
+    client = DioLoader(
+      widget.booruItem.fileURL,
+      headers: ViewUtils.getFileCustomHeaders(widget.searchGlobal, checkForReferer: true),
+      cancelToken: _dioCancelToken,
+      onEvent: _onEvent,
+    );
+    client!.runRequestSize();
+    return;
+  }
+
+  void onSize(int size) {
+    // TODO find a way to stop loading based on size when caching is enabled
+    final int maxSize = 1024 * 1024 * 200;
+    // print('onSize: $size $maxSize ${size > maxSize}');
+    if(size == 0) {
+      killLoading(['File is zero bytes']);
+    } else if ((size > maxSize) && isTooBig != 2) {
+      // TODO add check if resolution is too big
+      isTooBig = 1;
+      killLoading(['File is too big', 'File size: ${Tools.formatBytes(size, 2)}', 'Limit: ${Tools.formatBytes(maxSize, 2)}']);
+    }
+
+    if (size > 0 && widget.booruItem.fileSize == null) {
+      // set item file size if it wasn't received from api
+      widget.booruItem.fileSize = size;
+      // if(isAllowedToRestate) updateState();
+    }
+  }
+
   void _onBytesAdded(int received, int total) {
     // bool isAllowedToRestate = settingsHandler.videoCacheMode == 'Cache' || _video == null;
 
     _received.value = received;
     _total.value = total;
-    if (total > 0 && widget.booruItem.fileSize == null) {
-      // set item file size if it wasn't received from api
-      widget.booruItem.fileSize = total;
-      // if(isAllowedToRestate) updateState();
-    }
+    onSize(total);
   }
 
-  void _onEvent(String event) {
+  void _onEvent(String event, dynamic data) {
     switch (event) {
       case 'loaded':
         // 
+        break;
+      case 'size':
+        onSize(data);
         break;
       case 'isFromCache':
         isFromCache = true;
@@ -172,6 +207,29 @@ class _VideoAppDesktopState extends State<VideoAppDesktop> {
   void initState() {
     super.initState();
     viewerHandler.addViewed(widget.key);
+
+    isViewed = settingsHandler.appMode == 'Mobile'
+      ? searchHandler.viewedIndex.value == widget.index
+      : searchHandler.viewedItem.value.fileURL == widget.booruItem.fileURL;
+    indexListener = searchHandler.viewedIndex.listen((int value) {
+      final bool prevViewed = isViewed;
+      final bool isCurrentIndex = value == widget.index;
+      final bool isCurrentItem = searchHandler.viewedItem.value.fileURL == widget.booruItem.fileURL;
+      if (settingsHandler.appMode == 'Mobile' ? isCurrentIndex : isCurrentItem) {
+        isViewed = true;
+      } else {
+        isViewed = false;
+      }
+
+      if (prevViewed != isViewed) {
+        if (!isViewed) {
+          // reset zoom if not viewed
+          resetZoom();
+        }
+        updateState();
+      }
+    });
+
     initVideo(false);
   }
 
@@ -182,7 +240,7 @@ class _VideoAppDesktopState extends State<VideoAppDesktop> {
   }
 
   void initVideo(ignoreTagsCheck) {
-    // viewController..outputStateStream.listen(onViewStateChanged);
+    viewController..outputStateStream.listen(onViewStateChanged);
     scaleController..outputScaleStateStream.listen(onScaleStateChanged);
 
     if (widget.booruItem.isHated.value && !ignoreTagsCheck) {
@@ -218,6 +276,10 @@ class _VideoAppDesktopState extends State<VideoAppDesktop> {
   @override
   void dispose() {
     disposables();
+
+    indexListener?.cancel();
+    indexListener = null;
+
     viewerHandler.removeViewed(widget.key);
     super.dispose();
   }
@@ -250,6 +312,7 @@ class _VideoAppDesktopState extends State<VideoAppDesktop> {
 
   void onViewStateChanged(PhotoViewControllerValue viewState) {
     // print(viewState);
+    viewerHandler.setViewState(widget.key, viewState);
   }
 
   void resetZoom() {
@@ -350,21 +413,13 @@ class _VideoAppDesktopState extends State<VideoAppDesktop> {
 
   @override
   Widget build(BuildContext context) {
-    int viewedIndex = widget.searchGlobal.viewedIndex.value;
-    final bool isViewed = settingsHandler.appMode == 'Mobile'
-      ? viewedIndex == widget.index
-      : widget.searchGlobal.currentItem.value.fileURL == widget.booruItem.fileURL;
+    // print('!!! Build video desktop ${widget.index}!!!');
+    
     bool initialized = isLoaded; // videoController != null;
 
     // protects from video restart when something forces restate here while video is active (example: favoriting from appbar)
+    int viewedIndex = searchHandler.viewedIndex.value;
     bool needsRestart = _lastViewedIndex != viewedIndex;
-
-    if (!isViewed) {
-      // reset zoom if not viewed
-      resetZoom();
-    } else {
-      viewerHandler.setCurrent(widget.key);
-    }
 
     if (initialized) {
       if (isViewed) {
@@ -401,8 +456,6 @@ class _VideoAppDesktopState extends State<VideoAppDesktop> {
       _lastViewedIndex = viewedIndex;
     }
 
-    // print('!!! Build video desktop !!!');
-
     // TODO move controls outside, to exclude them from zoom
 
     return Hero(
@@ -422,6 +475,7 @@ class _VideoAppDesktopState extends State<VideoAppDesktop> {
                 hasProgress: settingsHandler.mediaCache && settingsHandler.videoCacheMode != 'Stream',
                 isFromCache: isFromCache,
                 isDone: initialized && firstViewFix,
+                isTooBig: isTooBig > 0,
                 isStopped: isStopped,
                 stopReasons: stopReason,
                 isViewed: isViewed,
@@ -429,6 +483,9 @@ class _VideoAppDesktopState extends State<VideoAppDesktop> {
                 received: _received,
                 startedAt: _startedAt,
                 startAction: () {
+                  if(isTooBig == 1) {
+                    isTooBig = 2;
+                  }
                   initVideo(true);
                   updateState();
                 },

--- a/lib/widgets/VideoAppPlaceholder.dart
+++ b/lib/widgets/VideoAppPlaceholder.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
@@ -9,16 +10,11 @@ import 'package:LoliSnatcher/libBooru/BooruItem.dart';
 import 'package:LoliSnatcher/widgets/CachedThumbBetter.dart';
 import 'package:LoliSnatcher/widgets/SettingsWidgets.dart';
 
-class VideoAppPlaceholder extends StatefulWidget {
+class VideoAppPlaceholder extends StatelessWidget {
   final BooruItem item;
   final int index;
   VideoAppPlaceholder({required this.item, required this.index});
 
-  @override
-  _VideoAppPlaceholderState createState() => _VideoAppPlaceholderState();
-}
-
-class _VideoAppPlaceholderState extends State<VideoAppPlaceholder> {
   final SearchHandler searchHandler = Get.find<SearchHandler>();
   @override
   Widget build(BuildContext context) {
@@ -26,7 +22,7 @@ class _VideoAppPlaceholderState extends State<VideoAppPlaceholder> {
       child: Stack(
         alignment: Alignment.center,
         children: [
-          CachedThumbBetter(widget.item, widget.index, searchHandler.currentTab, 1, false),
+          CachedThumbBetter(item, index, searchHandler.currentTab, 1, false),
           // Image.network(item.thumbnailURL, fit: BoxFit.fill),
           Container(
             width: MediaQuery.of(context).size.width / 3,
@@ -34,12 +30,43 @@ class _VideoAppPlaceholderState extends State<VideoAppPlaceholder> {
               name: Platform.isLinux ? 'Open Video in External Player' : 'Open Video in Browser',
               action: () {
                 if (Platform.isLinux) {
-                  Process.run('mpv', ["--loop", widget.item.fileURL]);
+                  Process.run('mpv', ["--loop", item.fileURL]);
                 } else {
-                  ServiceHandler.launchURL(widget.item.fileURL);
+                  ServiceHandler.launchURL(item.fileURL);
                 }
               },
               icon: Icon(Icons.play_arrow),
+              drawTopBorder: true,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class UnknownPlaceholder extends StatelessWidget {
+  final BooruItem item;
+  final int index;
+  UnknownPlaceholder({required this.item, required this.index});
+
+  final SearchHandler searchHandler = Get.find<SearchHandler>();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          CachedThumbBetter(item, index, searchHandler.currentTab, 1, false),
+          Container(
+            width: MediaQuery.of(context).size.width / 3,
+            child: SettingsButton(
+              name: 'Unknown file format, click here to open in browser',
+              action: () {
+                ServiceHandler.launchURL(item.postURL);
+              },
+              icon: Icon(CupertinoIcons.question),
               drawTopBorder: true,
             ),
           ),

--- a/lib/widgets/ViewerPage.dart
+++ b/lib/widgets/ViewerPage.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:LoliSnatcher/widgets/ChangePageButtons.dart';
+import 'package:LoliSnatcher/widgets/NotesRenderer.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -29,6 +31,7 @@ import 'package:LoliSnatcher/widgets/MediaViewerBetter.dart';
 import 'package:LoliSnatcher/widgets/FlashElements.dart';
 import 'package:LoliSnatcher/widgets/SettingsWidgets.dart';
 import 'package:LoliSnatcher/widgets/ZoomButton.dart';
+import 'package:LoliSnatcher/widgets/VideoAppPlaceholder.dart';
 import 'package:LoliSnatcher/libBooru/Booru.dart';
 import 'package:LoliSnatcher/libBooru/BooruItem.dart';
 import 'package:LoliSnatcher/libBooru/HydrusHandler.dart';
@@ -58,8 +61,7 @@ class _ViewerPageState extends State<ViewerPage> {
   Timer? autoScrollTimer;
   TimedProgressController? autoScrollProgressController;
 
-  PreloadPageController? controller;
-  PageController? controllerLinux;
+  late PreloadPageController controller;
   ImageWriter imageWriter = ImageWriter();
   FocusNode kbFocusNode = FocusNode();
   StreamSubscription? volumeListener;
@@ -114,10 +116,10 @@ class _ViewerPageState extends State<ViewerPage> {
 
   //         if (position.dx < (Get.width * 0.10) && isNotInLeftZoomButtonRange) {
   //           // next page if tapped on dx less than 10% of width
-  //           await controller?.previousPage(duration: Duration(milliseconds: 10), curve: Curves.easeInOut);
+  //           await controller.previousPage(duration: Duration(milliseconds: 10), curve: Curves.easeInOut);
   //         } else if (position.dx > (Get.width * 0.90) && isNotInRightZoomButtonRange) {
   //           // next page if tapped on dx more than 90% of width
-  //           await controller?.nextPage(duration: Duration(milliseconds: 10), curve: Curves.easeInOut);
+  //           await controller.nextPage(duration: Duration(milliseconds: 10), curve: Curves.easeInOut);
   //         }
   //       }
   //     }
@@ -131,15 +133,9 @@ class _ViewerPageState extends State<ViewerPage> {
     controller = PreloadPageController(
       initialPage: widget.index,
     );
-    controllerLinux = PageController(
-      initialPage: widget.index,
-    );
-    setState(() {
-      // print("widget index: ${widget.index}");
-      // print("searchglobals index: ${searchHandler.currentTab.viewedIndex.value}");
-      searchHandler.currentTab.currentItem.value = getFetched()[widget.index];
-      searchHandler.currentTab.viewedIndex.value = widget.index;
-    });
+
+    // print("widget index: ${widget.index}");
+    // print("searchglobals index: ${searchHandler.viewedIndex.value}");
 
     ServiceHandler.disableSleep();
     kbFocusNode.requestFocus();
@@ -149,7 +145,7 @@ class _ViewerPageState extends State<ViewerPage> {
     );
 
     // enable volume buttons if opened page is a video AND appbar is visible
-    BooruItem item = getFetched()[widget.index];
+    BooruItem item = searchHandler.currentFetched[widget.index];
     bool isVideo = item.isVideo();
     bool isHated = item.isHated.value;
     bool isVolumeAllowed = !settingsHandler.useVolumeButtonsForScroll || (isVideo && viewerHandler.displayAppbar.value);
@@ -157,18 +153,16 @@ class _ViewerPageState extends State<ViewerPage> {
     setVolumeListener();
   }
 
-  List<BooruItem> getFetched() {
-    // TODO this gets called too many times, find a way to call only when needed or once for all cases
-    return searchHandler.currentTab.booruHandler.filteredFetched;
-  }
-
   Widget getTitle() {
-    return Obx(() => Text("${(searchHandler.currentTab.viewedIndex.value + 1).toString()}/${searchHandler.currentTab.booruHandler.filteredFetched.length.toString()}", style: TextStyle(color: Colors.white)),);
+    return Obx(() {
+      final String formattedViewedIndex = (searchHandler.viewedIndex.value + 1).toString();
+      final String formattedTotal = searchHandler.currentFetched.length.toString(); 
+      return Text("$formattedViewedIndex/$formattedTotal", style: TextStyle(color: Colors.white));
+    });
   }
 
   @override
   Widget build(BuildContext context) {
-    // String appBarTitle = "${(searchHandler.currentTab.viewedIndex.value + 1).toString()}/${getFetched().length.toString()}";
     //kbFocusNode.requestFocus();
 
     return Scaffold(
@@ -189,14 +183,155 @@ class _ViewerPageState extends State<ViewerPage> {
           dismissThresholds: {DismissDirection.up: 0.2, DismissDirection.down: 0.2, DismissDirection.startToEnd: 0.3, DismissDirection.endToStart: 0.3}, // Amount of swiped away which triggers dismiss
           onDismissed: (_) => Navigator.of(context).pop(),
           child: Center(
-            // child: PhotoViewGestureDetectorScope(
-            //   // horizontal to prevent triggering page change early when panning
-            //   axis: Axis.horizontal,
-              // The pageView builder will created a page for each image in the booruList(fetched)
-              child: androidPageBuilder(),
-            // ),
-          )
-        )
+            child: RawKeyboardListener(
+              autofocus: false,
+              focusNode: kbFocusNode,
+              onKey: (RawKeyEvent event) async {
+                // print('viewer keyboard ${viewerHandler.inViewer.value}');
+
+                // detect only key DOWN events
+                if (event.runtimeType == RawKeyDownEvent) {
+                  if(event.physicalKey == PhysicalKeyboardKey.arrowLeft || event.physicalKey == PhysicalKeyboardKey.keyH) {
+                    // prev page on Left Arrow or H
+                    if(searchHandler.viewedIndex.value > 0) {
+                      controller.jumpToPage(searchHandler.viewedIndex.value - 1);
+                    }
+                  } else if(event.physicalKey == PhysicalKeyboardKey.arrowRight || event.physicalKey == PhysicalKeyboardKey.keyL) {
+                    // next page on Right Arrow or L
+                    if(searchHandler.viewedIndex.value < searchHandler.currentFetched.length - 1) {
+                      controller.jumpToPage(searchHandler.viewedIndex.value + 1);
+                    }
+                  } else if (event.physicalKey == PhysicalKeyboardKey.keyS) {
+                    // save on S
+                    snatchHandler.queue(
+                      [searchHandler.currentFetched[searchHandler.viewedIndex.value]],
+                      searchHandler.currentTab.selectedBooru.value,
+                      settingsHandler.snatchCooldown
+                    );
+                  } else if (event.physicalKey == PhysicalKeyboardKey.keyF) {
+                    // favorite on F
+                    if (settingsHandler.dbEnabled) {
+                      if(searchHandler.currentFetched[searchHandler.viewedIndex.value].isFavourite.value != null) {
+                        searchHandler.currentFetched[searchHandler.viewedIndex.value].isFavourite.toggle();
+                        settingsHandler.dbHandler.updateBooruItem(searchHandler.currentFetched[searchHandler.viewedIndex.value], "local");
+                      }
+                    }
+                  } else if (event.physicalKey == PhysicalKeyboardKey.escape) {
+                    // exit on escape if in focus
+                    if(kbFocusNode.hasFocus) {
+                      Navigator.of(context).pop();
+                    }
+                  }
+                }
+              },
+              child: Stack(children: [
+                Obx(() => PreloadPageView.builder( // PreloadPageView.PageView.builder(
+                  preloadPagesCount: settingsHandler.preloadCount,
+                  // allowImplicitScrolling: true,
+                  scrollDirection: settingsHandler.galleryScrollDirection == 'Vertical' ? Axis.vertical : Axis.horizontal,
+                  physics: const AlwaysScrollableScrollPhysics(parent: ClampingScrollPhysics()),
+                  itemBuilder: (context, index) {
+                    BooruItem item = searchHandler.currentFetched[index];
+                    // String fileURL = item.fileURL;
+                    bool isVideo = item.isVideo();
+                    bool isImage = item.isImage();
+                    // print(fileURL);
+                    // print('isVideo: '+isVideo.toString());
+                    // Render only if viewed or in preloadCount range
+
+                    late Widget itemWidget;
+                    if(isImage) {
+                      itemWidget = MediaViewerBetter(
+                        item.key,
+                        item,
+                        index,
+                        searchHandler.currentTab,
+                      );
+                    } else if(isVideo) {
+                      if(settingsHandler.disableVideo) {
+                        itemWidget = Center(child: Text("Video Disabled", style: TextStyle(fontSize: 20)));
+                      } else {
+                        if(Platform.isAndroid || Platform.isIOS) {
+                          itemWidget = VideoApp(item.key, item, index, searchHandler.currentTab, true);
+                        } else if(Platform.isWindows || Platform.isLinux) {
+                          itemWidget = VideoAppDesktop(item.key, item, index, searchHandler.currentTab);
+                        } else {
+                          return VideoAppPlaceholder(item: item, index: index);
+                        }
+                      }
+                    } else {
+                      itemWidget = UnknownPlaceholder(item: item, index: index);
+                    }
+
+                    // Cut to the size of the container, prevents overlapping
+                    return ClipRect(
+                      //Stack/Buttons Temp fix for desktop pageview only scrollable on like 2px at edges of screen. Think its a windows only bug
+                      child: GestureDetector(
+                        // onTapUp: (TapUpDetails tapInfo) {
+                        //   if(isVideo) return;
+                        //   // TODO WIP
+                        //   // change page if tapped on 20% of any side of the screen AND not a video
+                        //   double tapPosX = tapInfo.localPosition.dx;
+                        //   double screenWidth = MediaQuery.of(context).size.width;
+                        //   double sideThreshold = screenWidth / 5;
+
+                        //   if(tapPosX > (screenWidth - sideThreshold)) {
+                        //     controller.animateToPage(searchHandler.viewedIndex.value + 1, duration: Duration(milliseconds: 100), curve: Curves.easeInOut);
+                        //   } else if(tapPosX < sideThreshold) {
+                        //     controller.animateToPage(searchHandler.viewedIndex.value - 1, duration: Duration(milliseconds: 100), curve: Curves.easeInOut);
+                        //   }
+                        // },
+                        onLongPress: () async {
+                          // print('longpress');
+                          bool newAppbarVisibility = !viewerHandler.displayAppbar.value;
+                          viewerHandler.displayAppbar.value = newAppbarVisibility;
+
+                          ServiceHandler.vibrate();
+
+                          // enable volume buttons if current page is a video AND appbar is set to visible
+                          bool isVideo = searchHandler.currentFetched[searchHandler.viewedIndex.value].isVideo();
+                          bool isVolumeAllowed = !settingsHandler.useVolumeButtonsForScroll || (isVideo && newAppbarVisibility);
+                          ServiceHandler.setVolumeButtons(isVolumeAllowed);
+                        },
+                        child: itemWidget,
+                      ),
+                    );
+                  },
+                  controller: controller,
+                  onPageChanged: (int index) {
+                    // rehide system ui on every page change
+                    ServiceHandler.disableSleep();
+
+                    searchHandler.setViewedItem(index);
+                    kbFocusNode.requestFocus();
+
+                    viewerHandler.setCurrent(searchHandler.currentFetched[index].key);
+
+                    if(autoScroll) {
+                      if((autoScrollTimer?.isActive == true)) {
+                        // reset slideshow timer if user scrolled earlier
+                        // TODO bug: progress animation lags for a few frames when scroll is automatic
+                        unsetScrollTimer();
+                        setScrollTimer();
+                      }
+                    }
+
+                    // enable volume buttons if new page is a video AND appbar is visible
+                    bool isVideo = searchHandler.currentFetched[index].isVideo();
+                    bool isVolumeAllowed = !settingsHandler.useVolumeButtonsForScroll || (isVideo && viewerHandler.displayAppbar.value);
+                    ServiceHandler.setVolumeButtons(isVolumeAllowed);
+                    // print('Page changed ' + index.toString());
+                  },
+                  itemCount: searchHandler.currentFetched.length,
+                )),
+
+                NotesRenderer(),
+                ChangePageButtons(controller),
+                ZoomButton(),
+              ]),
+            ),
+          ),
+        ),
       ),
       endDrawerEnableOpenDragGesture: false,
       endDrawer: Theme(
@@ -210,20 +345,25 @@ class _ViewerPageState extends State<ViewerPage> {
 
   void setVolumeListener() {
     volumeListener?.cancel();
-    volumeListener = searchHandler.volumeStream?.stream.listen((event) {
-      // print('in gallery $event');
-      int dir = 0;
-      if (event == 'up') {
-        dir = -1;
-      } else if (event == 'down') {
-        dir = 1;
-      }
+    volumeListener = searchHandler.volumeStream?.stream.listen(volumeCallback);
+  }
+  void volumeCallback(String event) {
+    // print('in gallery $event');
+    int dir = 0;
+    if (event == 'up') {
+      dir = -1;
+    } else if (event == 'down') {
+      dir = 1;
+    }
 
-      // lastScrolledTo = math.max(math.min(lastScrolledTo + dir, getFetched().length), 0);
-      int toPage = searchHandler.currentTab.viewedIndex.value + dir; // lastScrolledTo; 
-      controller?.animateToPage(toPage, duration: Duration(milliseconds: 30), curve: Curves.easeInOut);
-      // controller?.jumpToPage(toPage);
-    });
+    if(kbFocusNode.hasFocus && dir != 0) { // disable volume scrolling when not in focus
+      // lastScrolledTo = math.max(math.min(lastScrolledTo + dir, searchHandler.currentFetched.length), 0);
+      int toPage = searchHandler.viewedIndex.value + dir; // lastScrolledTo;
+      // controller.animateToPage(toPage, duration: Duration(milliseconds: 30), curve: Curves.easeInOut);
+      if(toPage >= 0 && toPage < searchHandler.currentFetched.length) {
+        controller.jumpToPage(toPage);
+      }
+    }
   }
 
   @override
@@ -237,211 +377,16 @@ class _ViewerPageState extends State<ViewerPage> {
     super.dispose();
   }
 
-  Widget androidPageBuilder() {
-    return RawKeyboardListener(
-      autofocus: true,
-      focusNode: kbFocusNode,
-      onKey: (RawKeyEvent event) {
-        if(event.isKeyPressed(LogicalKeyboardKey.arrowLeft) || event.isKeyPressed(LogicalKeyboardKey.keyH)) {
-          controller?.previousPage(duration: Duration(milliseconds: 10), curve: Curves.linear);
-        } else if(event.isKeyPressed(LogicalKeyboardKey.arrowRight) || event.isKeyPressed(LogicalKeyboardKey.keyL)) {
-          controller?.nextPage(duration: Duration(milliseconds: 10), curve: Curves.linear);
-        } else if (event.isKeyPressed(LogicalKeyboardKey.keyS)) {
-          snatchHandler.queue(
-            [getFetched()[searchHandler.currentTab.viewedIndex.value]],
-            searchHandler.currentTab.selectedBooru.value,
-            settingsHandler.snatchCooldown
-          );
-        } else if (event.isKeyPressed(LogicalKeyboardKey.keyF)) {
-          if (settingsHandler.dbEnabled) {
-            if(getFetched()[searchHandler.currentTab.viewedIndex.value].isFavourite.value != null) {
-              setState(() {
-                getFetched()[searchHandler.currentTab.viewedIndex.value].isFavourite.toggle();
-                settingsHandler.dbHandler.updateBooruItem(getFetched()[searchHandler.currentTab.viewedIndex.value], "local");
-              });
-            }
-          }
-        }
-      },
-      child: Stack(children: [
-        PreloadPageView.builder( // PreloadPageView.PageView.builder(
-          preloadPagesCount: settingsHandler.preloadCount,
-          // allowImplicitScrolling: true,
-          scrollDirection: settingsHandler.galleryScrollDirection == 'Vertical' ? Axis.vertical : Axis.horizontal,
-          physics: const AlwaysScrollableScrollPhysics(parent: ClampingScrollPhysics()),
-          itemBuilder: (context, index) {
-            BooruItem item = getFetched()[index];
-            // String fileURL = item.fileURL;
-            bool isVideo = item.isVideo();
-            int preloadCount = settingsHandler.preloadCount;
-            bool isViewed = searchHandler.currentTab.viewedIndex.value == index;
-            bool isNear = (searchHandler.currentTab.viewedIndex.value - index).abs() <= preloadCount;
-            // print(fileURL);
-            // print('isVideo: '+isVideo.toString());
-            // Render only if viewed or in preloadCount range
-
-            late Widget itemWidget;
-            if(isVideo) {
-              if(settingsHandler.disableVideo) {
-                itemWidget = Center(child: Text("Video Disabled", style: TextStyle(fontSize: 20)));
-              } else {
-                if(Platform.isAndroid || Platform.isIOS) {
-                  itemWidget = VideoApp(
-                    item.key,
-                    item,
-                    index,
-                    searchHandler.currentTab,
-                    true
-                  );
-                } else {
-                  itemWidget = VideoAppDesktop(item.key, item, index, searchHandler.currentTab);
-                }
-              }
-            } else {
-              itemWidget = MediaViewerBetter(
-                item.key,
-                item,
-                index,
-                searchHandler.currentTab
-              );
-            }
-
-            if (isViewed || isNear) {
-              // Cut to the size of the container, prevents overlapping
-              return ClipRect(
-                //Stack/Buttons Temp fix for desktop pageview only scrollable on like 2px at edges of screen. Think its a windows only bug
-                child: Stack(children: [
-                  GestureDetector(
-                    // onTapUp: (TapUpDetails tapInfo) {
-                    //   if(isVideo) return;
-                    //   // TODO WIP
-                    //   // change page if tapped on 20% of any side of the screen AND not a video
-                    //   double tapPosX = tapInfo.localPosition.dx;
-                    //   double screenWidth = MediaQuery.of(context).size.width;
-                    //   double sideThreshold = screenWidth / 5;
-
-                    //   if(tapPosX > (screenWidth - sideThreshold)) {
-                    //     controller?.animateToPage(searchHandler.currentTab.viewedIndex.value + 1, duration: Duration(milliseconds: 100), curve: Curves.easeInOut);
-                    //   } else if(tapPosX < sideThreshold) {
-                    //     controller?.animateToPage(searchHandler.currentTab.viewedIndex.value - 1, duration: Duration(milliseconds: 100), curve: Curves.easeInOut);
-                    //   }
-                    // },
-                    onLongPress: () async {
-                      print('longpress');
-                      bool newAppbarVisibility = !viewerHandler.displayAppbar.value;
-                      viewerHandler.displayAppbar.value = newAppbarVisibility;
-
-                      ServiceHandler.vibrate();
-
-                      // enable volume buttons if current page is a video AND appbar is set to visible
-                      bool isVideo = getFetched()[searchHandler.currentTab.viewedIndex.value].isVideo();
-                      bool isVolumeAllowed = !settingsHandler.useVolumeButtonsForScroll || (isVideo && newAppbarVisibility);
-                      ServiceHandler.setVolumeButtons(isVolumeAllowed);
-                    },
-                    child: itemWidget,
-                  ),
-
-                  if(!(Platform.isAndroid || Platform.isIOS) && viewerHandler.displayAppbar.value)
-                    Container(
-                      alignment: Alignment.bottomRight,
-                      margin: EdgeInsets.all(60),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.end,
-                        children: [
-                          Container(
-                            width: 35,
-                            height: 35,
-                            margin: EdgeInsets.all(10),
-                            child: FloatingActionButton(
-                              heroTag: 'prevArrow-$index',
-                              onPressed: () {
-                                if((index - 1) >= 0) {
-                                  controller!.animateToPage(
-                                      controller!.page!.toInt() - 1,
-                                      duration: Duration(milliseconds: 400),
-                                      curve: Curves.linear
-                                  );
-                                }
-                              },
-                              child: Icon(Icons.arrow_left),
-                              backgroundColor: Get.context!.theme.colorScheme.secondary,
-                            ),
-                          ),
-                          Container(
-                            width: 35,
-                            height: 35,
-                            margin: EdgeInsets.all(10),
-                            child: FloatingActionButton(
-                              heroTag: 'nextArrow-$index',
-                              onPressed: () {
-                                if((index + 1) < getFetched().length) {
-                                  controller!.animateToPage(
-                                      controller!.page!.toInt() + 1,
-                                      duration: Duration(milliseconds: 400),
-                                      curve: Curves.linear
-                                  );
-                                }
-                              },
-                              child: Icon(Icons.arrow_right),
-                              backgroundColor: Get.context!.theme.colorScheme.secondary,
-                            ),
-                          ),
-                        ],
-                      )
-                    ),
-                ])
-              );
-            } else {
-              return Container(
-                color: Colors.black,
-              );
-            }
-          },
-          controller: controller,
-          onPageChanged: (int index) {
-            // rehide system ui on every page change
-            ServiceHandler.disableSleep();
-
-            setState(() {
-              searchHandler.currentTab.currentItem.value = getFetched()[index];
-              searchHandler.currentTab.viewedIndex.value = index;
-              kbFocusNode.requestFocus();
-            });
-
-            if(autoScroll) {
-              if((autoScrollTimer?.isActive == true)) {
-                // reset slideshow timer if user scrolled earlier
-                // TODO bug: progress animation lags for a few frames when scroll is automatic
-                unsetScrollTimer();
-                setScrollTimer();
-              }
-            }
-
-            // enable volume buttons if new page is a video AND appbar is visible
-            bool isVideo = getFetched()[index].isVideo();
-            bool isVolumeAllowed = !settingsHandler.useVolumeButtonsForScroll || (isVideo && viewerHandler.displayAppbar.value);
-            ServiceHandler.setVolumeButtons(isVolumeAllowed);
-            // print('Page changed ' + index.toString());
-          },
-          itemCount: getFetched().length,
-        ),
-
-        ZoomButton(),
-      ]),
-    );
-  }
-
   void scrollToNextPage() {
     // Not sure if video and gifs should be autoscrolled, could maybe add a listener for video playtime so it changes at the end
-    final int viewedIndex = searchHandler.currentTab.viewedIndex.value;
-    final bool isImage = getFetched()[viewedIndex].mediaType == "image";
-    if((viewedIndex + 1) < getFetched().length) {
-      if (viewedIndex == controller!.page!.toInt() && isImage && autoScroll){
+    final int viewedIndex = searchHandler.viewedIndex.value;
+    final bool isImage = searchHandler.currentFetched[viewedIndex].mediaType == "image";
+    // TODO video and gifs support
+    // TODO check if item is loaded
+    if(viewedIndex < (searchHandler.currentFetched.length - 1)) {
+      if (isImage && autoScroll) {
         print("autoscrolling");
-        controller!.animateToPage(controller!.page!.toInt() + 1,
-            duration: Duration(milliseconds: 400),
-            curve: Curves.linear
-        );
+        controller.jumpToPage(viewedIndex + 1);
       }
     } else {
       autoScrollState(false);
@@ -459,7 +404,7 @@ class _ViewerPageState extends State<ViewerPage> {
     autoScrollProgressController?.stop();
   }
   void autoScrollState(bool newState) {
-    bool isNotLastPage = (searchHandler.currentTab.viewedIndex.value + 1) < getFetched().length;
+    bool isNotLastPage = (searchHandler.viewedIndex.value + 1) < searchHandler.currentFetched.length;
     if(autoScroll != newState) {
       if(isNotLastPage) {
         setState(() {
@@ -491,43 +436,6 @@ class _ViewerPageState extends State<ViewerPage> {
     }
   }
 
-  // Might not be needed anymore prelaodpageview is nw working on flutter linux, might not work with go-flutter though
-  Widget linuxPageBuilder() {
-    return PageView.builder(
-        controller: controllerLinux,
-        scrollDirection: Axis.horizontal,
-        itemBuilder: (context, index) {
-          String fileURL = getFetched()[index].fileURL;
-          bool isVideo = getFetched()[index].isVideo();
-          if (isVideo) {
-            return Container(
-              child: Column(
-                children: [
-                  Image.network(getFetched()[index].thumbnailURL),
-                  Container(
-                    margin: EdgeInsets.fromLTRB(10, 10, 10, 10),
-                    child: TextButton(
-                      style: TextButton.styleFrom(
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(20),
-                          side: BorderSide(color: Get.theme.colorScheme.secondary),
-                        ),
-                      ),
-                      onPressed: () {
-                        Process.run('mpv', ["--loop", fileURL]);
-                      },
-                      child: Text("Open in MPV"),
-                    ),
-                  )
-                ],
-              ),
-            );
-          } else {
-            return Image.network(fileURL);
-          }
-        });
-  }
-
   Widget renderDrawer() {
     final MediaQueryData mQuery = MediaQuery.of(context);
     final double maxWidth = mQuery.orientation == Orientation.portrait ? (mQuery.size.width * 0.75) : (mQuery.size.height * 0.75);
@@ -536,7 +444,7 @@ class _ViewerPageState extends State<ViewerPage> {
       width: maxWidth,
       child: Drawer(
         child: SafeArea(
-          child: TagView(getFetched()[searchHandler.currentTab.viewedIndex.value])
+          child: TagView(),
         ),
       )
     );
@@ -575,7 +483,7 @@ class _ViewerPageState extends State<ViewerPage> {
 
 
   void shareFileAction() async {
-    BooruItem item = getFetched()[searchHandler.currentTab.viewedIndex.value];
+    BooruItem item = searchHandler.currentFetched[searchHandler.viewedIndex.value];
     String? path = await imageWriter.getCachePath(item.fileURL, 'media');
     ServiceHandler serviceHandler = ServiceHandler();
 
@@ -651,7 +559,7 @@ class _ViewerPageState extends State<ViewerPage> {
             const SizedBox(height: 15),
           Column(
             children: [
-              if(getFetched()[searchHandler.currentTab.viewedIndex.value].postURL != '')
+              if(searchHandler.currentFetched[searchHandler.viewedIndex.value].postURL != '')
                 ListTile(
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(10),
@@ -659,7 +567,7 @@ class _ViewerPageState extends State<ViewerPage> {
                     ),
                   onTap: (){
                     Navigator.of(context).pop();
-                    shareTextAction(getFetched()[searchHandler.currentTab.viewedIndex.value].postURL);
+                    shareTextAction(searchHandler.currentFetched[searchHandler.viewedIndex.value].postURL);
                   },
                   leading: Icon(CupertinoIcons.link),
                   title: Text('Post URL'),
@@ -673,7 +581,7 @@ class _ViewerPageState extends State<ViewerPage> {
                   ),
                   onTap: (){
                     Navigator.of(context).pop();
-                    shareTextAction(getFetched()[searchHandler.currentTab.viewedIndex.value].fileURL);
+                    shareTextAction(searchHandler.currentFetched[searchHandler.viewedIndex.value].fileURL);
                   },
                   leading: Icon(CupertinoIcons.link),
                   title: Text('File URL'),
@@ -702,7 +610,7 @@ class _ViewerPageState extends State<ViewerPage> {
                       ),
                       onTap: (){
                         Navigator.of(context).pop();
-                        shareHydrusAction(getFetched()[searchHandler.currentTab.viewedIndex.value]);
+                        shareHydrusAction(searchHandler.currentFetched[searchHandler.viewedIndex.value]);
                       },
                       leading: Icon(Icons.file_present),
                       title: Text('Hydrus'),
@@ -720,12 +628,12 @@ class _ViewerPageState extends State<ViewerPage> {
 
   List<Widget> appBarActions() {
     List<List<String>> filteredButtonOrder = settingsHandler.buttonOrder.where((btn) {
-      bool isVideoItem = getFetched()[searchHandler.currentTab.viewedIndex.value].isVideo();
+      bool isImageItem = searchHandler.currentFetched[searchHandler.viewedIndex.value].isImage();
       bool isScaleButton = btn[0] == 'reloadnoscale';
-      bool isScaleAllowed = isScaleButton ? (!isVideoItem || !settingsHandler.disableImageScaling) : true; // allow reloadnoscale button if not a video, or scaling is not disabled
+      bool isScaleAllowed = isScaleButton ? (isImageItem && !settingsHandler.disableImageScaling) : true; // allow reloadnoscale button if not a video and scaling is not disabled
 
       bool isFavButton = btn[0] == 'favourite';
-      bool isFavAllowed = isFavButton ? settingsHandler.dbEnabled : true; // allow favourite button if db isenabled
+      bool isFavAllowed = isFavButton ? settingsHandler.dbEnabled : true; // allow favourite button if db is enabled
       
       return isScaleAllowed && isFavAllowed;
     }).toList();
@@ -760,7 +668,7 @@ class _ViewerPageState extends State<ViewerPage> {
     //   icon: Icon(Icons.developer_board),
     //   color: Colors.white,
     //   onPressed: () {
-    //     print(searchHandler.currentTab.currentItem.value.toJSON().toString());
+    //     print(searchHandler.viewedItem.value.toJSON().toString());
     //   },
     // ));
 
@@ -867,7 +775,7 @@ class _ViewerPageState extends State<ViewerPage> {
         // icon = isFav == true ? Icons.favorite : Icons.favorite_border;
         // early return to override with animated icon
         return Obx(() {
-          final bool? isFav = getFetched()[searchHandler.currentTab.viewedIndex.value].isFavourite.value;
+          final bool? isFav = searchHandler.currentFetched[searchHandler.viewedIndex.value].isFavourite.value;
           return AnimatedCrossFade(
             duration: Duration(milliseconds: 200),
             crossFadeState: isFav == true ? CrossFadeState.showFirst : CrossFadeState.showSecond,
@@ -889,7 +797,7 @@ class _ViewerPageState extends State<ViewerPage> {
     switch (action) {
       case 'snatch':
         return Obx(() {
-          final bool isSnatched = getFetched()[searchHandler.currentTab.viewedIndex.value].isSnatched.value == true;
+          final bool isSnatched = searchHandler.currentFetched[searchHandler.viewedIndex.value].isSnatched.value == true;
           if(!isSnatched) {
             return const SizedBox();
           } else {
@@ -915,10 +823,10 @@ class _ViewerPageState extends State<ViewerPage> {
         label = "${autoScroll ? 'Pause' : 'Start'} $defaultLabel";
         break;
       case("favourite"):
-        label = getFetched()[searchHandler.currentTab.viewedIndex.value].isFavourite.value == true ? 'Unfavourite' : defaultLabel;
+        label = searchHandler.currentFetched[searchHandler.viewedIndex.value].isFavourite.value == true ? 'Unfavourite' : defaultLabel;
         break;
       case("reloadnoscale"):
-        label = getFetched()[searchHandler.currentTab.viewedIndex.value].isNoScale.value ? 'Reload with scaling' : defaultLabel;
+        label = searchHandler.currentFetched[searchHandler.viewedIndex.value].isNoScale.value ? 'Reload with scaling' : defaultLabel;
         break;
       default:
         // use default text
@@ -935,7 +843,7 @@ class _ViewerPageState extends State<ViewerPage> {
         viewerScaffoldKey.currentState?.openEndDrawer();
         break;
       case("open"):
-        ServiceHandler.launchURL(getFetched()[searchHandler.currentTab.viewedIndex.value].postURL);
+        ServiceHandler.launchURL(searchHandler.currentFetched[searchHandler.viewedIndex.value].postURL);
         break;
       case("autoscroll"):
         autoScrollState(!autoScroll);
@@ -944,28 +852,24 @@ class _ViewerPageState extends State<ViewerPage> {
         getPerms();
         // call a function to save the currently viewed image when the save button is pressed
         snatchHandler.queue(
-          [getFetched()[searchHandler.currentTab.viewedIndex.value]],
+          [searchHandler.currentFetched[searchHandler.viewedIndex.value]],
           searchHandler.currentTab.selectedBooru.value,
           settingsHandler.snatchCooldown
         );
         break;
       case("favourite"):
-        if(getFetched()[searchHandler.currentTab.viewedIndex.value].isFavourite.value != null) {
+        if(searchHandler.currentFetched[searchHandler.viewedIndex.value].isFavourite.value != null) {
           ServiceHandler.vibrate();
 
-          setState(() {
-            getFetched()[searchHandler.currentTab.viewedIndex.value].isFavourite.toggle();
-            settingsHandler.dbHandler.updateBooruItem(getFetched()[searchHandler.currentTab.viewedIndex.value], "local");
-          });
+          searchHandler.currentFetched[searchHandler.viewedIndex.value].isFavourite.toggle();
+          settingsHandler.dbHandler.updateBooruItem(searchHandler.currentFetched[searchHandler.viewedIndex.value], "local");
         }
         break;
       case("share"):
         onShareClick();
         break;
       case("reloadnoscale"):
-        setState(() {
-          getFetched()[searchHandler.currentTab.viewedIndex.value].isNoScale.toggle();
-        });
+        searchHandler.currentFetched[searchHandler.viewedIndex.value].isNoScale.toggle();
         break;
     }
   }
@@ -984,8 +888,8 @@ class _ViewerPageState extends State<ViewerPage> {
     String shareSetting = settingsHandler.shareAction;
     switch(shareSetting) {
       case 'Post URL':
-        if(getFetched()[searchHandler.currentTab.viewedIndex.value].postURL != '') {
-          shareTextAction(getFetched()[searchHandler.currentTab.viewedIndex.value].postURL);
+        if(searchHandler.currentFetched[searchHandler.viewedIndex.value].postURL != '') {
+          shareTextAction(searchHandler.currentFetched[searchHandler.viewedIndex.value].postURL);
         } else {
           FlashElements.showSnackbar(
             context: context,
@@ -1000,10 +904,10 @@ class _ViewerPageState extends State<ViewerPage> {
         }
         break;
       case 'File URL':
-        shareTextAction(getFetched()[searchHandler.currentTab.viewedIndex.value].fileURL);
+        shareTextAction(searchHandler.currentFetched[searchHandler.viewedIndex.value].fileURL);
         break;
       case 'Hydrus':
-        shareHydrusAction(getFetched()[searchHandler.currentTab.viewedIndex.value]);
+        shareHydrusAction(searchHandler.currentFetched[searchHandler.viewedIndex.value]);
         break;
       case 'File':
         shareFileAction();

--- a/lib/widgets/WaterfallErrorButtons.dart
+++ b/lib/widgets/WaterfallErrorButtons.dart
@@ -1,0 +1,166 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:LoliSnatcher/SearchGlobals.dart';
+import 'package:LoliSnatcher/widgets/SettingsWidgets.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class WaterfallErrorButtons extends StatefulWidget {
+  WaterfallErrorButtons({Key? key}) : super(key: key);
+
+  @override
+  _WaterfallErrorButtonsState createState() => _WaterfallErrorButtonsState();
+}
+
+class _WaterfallErrorButtonsState extends State<WaterfallErrorButtons> {
+  final SearchHandler searchHandler = Get.find<SearchHandler>();
+
+  int _startedAt = 0;
+  Timer? checkInterval;
+  StreamSubscription<bool>? loadingListener;
+
+  @override
+  void initState() {
+    super.initState();
+    startTimer();
+    loadingListener = searchHandler.isLoading.listen((bool isLoading) {
+      if(isLoading) {
+        startTimer();
+      } else {
+        stopTimer();
+      }
+    });
+  }
+
+  void updateState() {
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  void startTimer() {
+    if (_startedAt == 0) {
+      _startedAt = DateTime.now().millisecondsSinceEpoch;
+      checkInterval?.cancel();
+      checkInterval = Timer.periodic(const Duration(seconds: 1), (timer) {
+        // force restate every second to refresh all timers/indicators, even when loading has stopped/slowed down
+        updateState();
+      });
+    }
+  }
+
+  void stopTimer() {
+    _startedAt = 0;
+    checkInterval?.cancel();
+    updateState();
+  }
+
+  @override
+  void dispose() {
+    checkInterval?.cancel();
+    loadingListener?.cancel();
+    super.dispose();
+  }
+
+
+  Widget wrapButton(Widget child) {
+    return Container(color: Get.theme.colorScheme.background.withOpacity(0.66), child: child);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final String errorFormatted = searchHandler.currentBooruHandler.errorString.isNotEmpty ? '\n${searchHandler.currentBooruHandler.errorString}' : '';
+    final String clickName = (Platform.isWindows || Platform.isLinux) ? 'Click' : 'Tap';
+    int nowMils = DateTime.now().millisecondsSinceEpoch;
+    int sinceStart = _startedAt == 0 ? 0 : Duration(milliseconds: nowMils - _startedAt).inSeconds;
+    String sinceStartText = sinceStart > 0 ? 'Started ${sinceStart.toString()} second${sinceStart == 1 ? '' : 's'} ago' : '';
+
+    return Obx(() {
+      if(searchHandler.isLastPage.value) {
+        // if last page...
+        if(searchHandler.currentFetched.length == 0) {
+          // ... and no items loaded
+          return wrapButton(SettingsButton(
+            name: 'No Data Loaded',
+            subtitle: Text('$clickName Here to Reload'),
+            icon: Icon(Icons.refresh),
+            dense: true,
+            action: () {
+              searchHandler.retrySearch();
+            },
+            drawBottomBorder: false,
+          ));
+        } else { //if(searchHandler.currentFetched.length > 0) {
+          // .. has items loaded
+          return wrapButton(SettingsButton(
+            name: 'You Reached the End (${searchHandler.currentBooruHandler.pageNum} ${searchHandler.currentBooruHandler.pageNum.value == 1 ? 'page' : 'pages'})',
+            subtitle: Text('$clickName Here to Reload Last Page'),
+            icon: Icon(Icons.refresh),
+            dense: true,
+            action: () {
+              searchHandler.retrySearch();
+            },
+            drawBottomBorder: false,
+          ));
+        }
+      } else {
+        // if not last page...
+        if(searchHandler.isLoading.value) {
+          // ... and is currently loading
+          return wrapButton(SettingsButton(
+            name: 'Loading Page #${searchHandler.currentBooruHandler.pageNum}',
+            subtitle: AnimatedOpacity(
+              opacity: sinceStartText.isNotEmpty ? 1.0 : 0.0,
+              duration: const Duration(milliseconds: 200),
+              child: Text(sinceStartText),
+            ),
+            icon: SizedBox(
+              width: 30,
+              height: 30,
+              child: CircularProgressIndicator(
+                valueColor: AlwaysStoppedAnimation(Get.theme.colorScheme.secondary)
+              ),
+            ),
+            dense: true,
+            action: () {
+              searchHandler.retrySearch();
+            },
+            drawBottomBorder: false,
+          ));
+        } else {
+          if (searchHandler.currentBooruHandler.errorString.isNotEmpty) {
+            // ... if error happened
+            return wrapButton(SettingsButton(
+              name: 'Error happened when Loading Page #${searchHandler.currentBooruHandler.pageNum}: $errorFormatted',
+              subtitle: Text('$clickName Here to Retry'),
+              icon: Icon(Icons.refresh),
+              dense: true,
+              action: () {
+                searchHandler.retrySearch();
+              },
+              drawBottomBorder: false,
+            ));
+          } else if(searchHandler.currentFetched.length == 0) {
+            // ... no items loaded
+            return wrapButton(SettingsButton(
+              name: 'Error, no data loaded:',
+              subtitle: Text('$clickName Here to Retry'),
+              icon: Icon(Icons.refresh),
+              dense: true,
+              action: () {
+                searchHandler.retrySearch();
+              },
+              drawBottomBorder: false,
+            ));
+          } else {
+            // return const SizedBox.shrink();
+
+            // add a small container to avoid scrolling when swiping from the bottom of the screen (navigation gestures)
+            return Container(height: 10, color: Colors.transparent);
+          }
+        }
+      }
+    });
+  }
+}

--- a/lib/widgets/WaterfallView.dart
+++ b/lib/widgets/WaterfallView.dart
@@ -1,30 +1,25 @@
 import 'dart:async';
-import 'dart:io';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_improved_scrolling/flutter_improved_scrolling.dart';
 import 'package:get/get.dart';
-import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
-import 'package:waterfall_flow/waterfall_flow.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 
 import 'package:LoliSnatcher/SearchGlobals.dart';
 import 'package:LoliSnatcher/SettingsHandler.dart';
-import 'package:LoliSnatcher/ViewUtils.dart';
 import 'package:LoliSnatcher/ServiceHandler.dart';
 import 'package:LoliSnatcher/libBooru/BooruItem.dart';
 import 'package:LoliSnatcher/ViewerHandler.dart';
-import 'package:LoliSnatcher/widgets/FlashElements.dart';
 import 'package:LoliSnatcher/widgets/ViewerPage.dart';
-import 'package:LoliSnatcher/widgets/CachedThumbBetter.dart';
-import 'package:LoliSnatcher/widgets/SettingsWidgets.dart';
+import 'package:LoliSnatcher/widgets/GridBuilder.dart';
+import 'package:LoliSnatcher/widgets/StaggeredBuilder.dart';
+import 'package:LoliSnatcher/widgets/WaterfallErrorButtons.dart';
 
 class WaterfallView extends StatefulWidget {
   final SearchGlobal tab;
-  final int globalIndex;
-  WaterfallView(this.tab, this.globalIndex);
+  WaterfallView(this.tab);
   @override
   _WaterfallState createState() => _WaterfallState();
 }
@@ -34,19 +29,29 @@ class _WaterfallState extends State<WaterfallView> {
   final SearchHandler searchHandler = Get.find<SearchHandler>();
   final ViewerHandler viewerHandler = Get.find<ViewerHandler>();
 
-  Timer? loadingDelay, checkInterval;
+  Timer? loadingDelay;
   FocusNode kbFocusNode = FocusNode();
   StreamSubscription? volumeListener;
-  StreamSubscription? viewedListener;
-
-  int _startedAt = 0;
+  bool scrollDone = true;
+  StreamSubscription? viewedListener, isLoadingListener;
 
   @override
   void initState() {
     super.initState();
+
+    // scroll to current viewed item
+    viewedListener = searchHandler.viewedIndex.listen(jumpTo);
+
+    // listen to isLoading to select first loaded item for desktop
+    isLoadingListener = searchHandler.isLoading.listen((bool isLoading) {
+      if (!isLoading) {
+        afterSearch();
+      }
+    });
+
+    setVolumeListener();
+
     initView();
-    // TODO move all load logic to SearchHandler
-    searchHandler.filteredSearch = filteredSearch;
   }
 
   @override
@@ -58,166 +63,108 @@ class _WaterfallState extends State<WaterfallView> {
     super.didUpdateWidget(oldWidget);
   }
 
-  void updateState() {
-    if(this.mounted) {
-      setState(() {});
-    }
-  }
-
   void initView() {
     // reset bools
-    searchHandler.isLastPage(false);
-    searchHandler.isLoading(true);
-    viewerHandler.inViewer(false);
-
-    updateState();
+    viewerHandler.inViewer.value = false;
 
     // restore scroll position on tab change
     if (searchHandler.gridScrollController.hasClients) {
-      searchHandler.gridScrollController.jumpTo(widget.tab.scrollPosition);
-    } else { // if (widget.tab.scrollPosition != 0) {
-      searchHandler.gridScrollController = AutoScrollController(initialScrollOffset: widget.tab.scrollPosition);
+      searchHandler.gridScrollController.jumpTo(searchHandler.currentTab.scrollPosition);
+    } else { // if (searchHandler.currentTab.scrollPosition != 0) {
+      // TODO reset the controller when appMode changes
+      searchHandler.gridScrollController = AutoScrollController(
+        initialScrollOffset: searchHandler.currentTab.scrollPosition,
+        viewportBoundaryGetter: () => Rect.fromLTRB(0, settingsHandler.appMode == 'Desktop' ? 0 : (kToolbarHeight + 2), 0, 0),
+      );
     }
 
-    viewedListener = widget.tab.viewedIndex.listen((int newValue) {
-      jumpTo();
-    });
+    // reser the volume butons state
     ServiceHandler.setVolumeButtons(!settingsHandler.useVolumeButtonsForScroll);
-    setVolumeListener();
-
-    // restore isLastPage state
-    if(widget.tab.booruHandler.locked.value) {
-      searchHandler.isLastPage(true);
-    }
-
-    // trigger first load OR get old filteredFetched list
-    bool isNewSearch = widget.tab.booruHandler.filteredFetched.length == 0;
-    // print('isNEW: $isNewSearch ${widget.globalIndex} ${widget.tab.id}');
-    if(isNewSearch) { // don't trigger search if there are items inside booruHandler
-      filteredSearch();
-      // searchHandler.searchAction(widget.tab.tags, null);
-    } else {
-      searchHandler.isLoading(false);
-    }
-
-    updateState();
 
     // print('GRID INIT');
   }
 
   void setVolumeListener() {
     volumeListener?.cancel();
-    volumeListener = searchHandler.volumeStream?.stream.listen((event) {
-      if(!viewerHandler.inViewer.value) {
-        int dir = 0;
-        if (event == 'up') {
-          dir = -1;
-        } else if (event == 'down') {
-          dir = 1;
-        }
-
-        final double offset = max(searchHandler.gridScrollController.offset + (settingsHandler.volumeButtonsScrollSpeed * dir), -20);
-        searchHandler.gridScrollController.animateTo(offset, duration: Duration(milliseconds: 200), curve: Curves.linear);
+    volumeListener = searchHandler.volumeStream?.stream.listen(volumeCallback);
+  }
+  void volumeCallback(String event) async {
+    if(!viewerHandler.inViewer.value) {
+      int dir = 0;
+      if (event == 'up') {
+        dir = -1;
+      } else if (event == 'down') {
+        dir = 1;
       }
-    });
+
+      // TODO disable when not in focus (i.e. opened settings/drawer), right now if focus is lost, this widget can't regain it
+      if(dir != 0 && scrollDone == true) {
+        scrollDone = false;
+        final double offset = max(searchHandler.gridScrollController.offset + (settingsHandler.volumeButtonsScrollSpeed * dir), -20);
+        await searchHandler.gridScrollController.animateTo(offset, duration: Duration(milliseconds: 200), curve: Curves.linear);
+        scrollDone = true;
+      }
+    }
   }
 
   @override
   void dispose() {
     viewedListener?.cancel();
+    isLoadingListener?.cancel();
     kbFocusNode.dispose();
     volumeListener?.cancel();
     ServiceHandler.setVolumeButtons(true);
     loadingDelay?.cancel();
-    checkInterval?.cancel();
     super.dispose();
   }
 
-  void jumpTo() {
-    // ViewUtils.jumpToItem(searchHandler.viewedIndex.value, searchHandler, searchHandler.gridScrollController, context);
-    searchHandler.gridScrollController.scrollToIndex(
-      widget.tab.viewedIndex.value,
-      duration: Duration(milliseconds: 50),
-      preferPosition: AutoScrollPosition.begin
-    );
+  void jumpTo(int newIndex) async {
+    if(newIndex == -1) {
+      return;
+    }
+
+    if(!viewerHandler.inViewer.value && settingsHandler.appMode == 'Mobile') {
+      await Future.delayed(Duration(milliseconds: 500));
+    }
+
+    if(newIndex == 0) {
+      // viewedIndex == 0 when tab is first created, so we should scroll to top on 0th item (not to the item itself, because there is padding on top of it) to avoid bugs with appbar
+      searchHandler.gridScrollController.jumpTo(0);
+    } else {
+      // scroll to viewed item
+      searchHandler.gridScrollController.scrollToIndex(
+        newIndex,
+        duration: Duration(milliseconds: 50),
+        preferPosition: AutoScrollPosition.begin
+      );
+    }
   }
 
-  Future<void> filteredSearch() async {
-    // do nothing if reached the end or detected an error
-    if(searchHandler.isLastPage.value) return;
-    if(widget.tab.booruHandler.errorString.isNotEmpty) return;
-
-    // request total image count if not already loaded
-    if(widget.tab.booruHandler.totalCount.value == 0) {
-      widget.tab.booruHandler.searchCount(widget.tab.tags);
-    }
-
-    // if not last page - set loading state and increment page
-    if (!widget.tab.booruHandler.locked.value) {
-      searchHandler.isLoading(true);
-      widget.tab.booruHandler.pageNum++;
-    }
-    updateState();
-
-    // fetch new items, but get results from booruHandler and not search itself
-    _startedAt = DateTime.now().millisecondsSinceEpoch;
-    checkInterval?.cancel();
-    checkInterval = Timer.periodic(const Duration(seconds: 1), (timer) {
-      // force restate every second to refresh all timers/indicators, even when loading has stopped
-      updateState();
-    });
-    await widget.tab.booruHandler.Search(widget.tab.tags, null);
-    checkInterval?.cancel();
-    _startedAt = 0;
-    // print('FINISHED SEARCH: ${temp.length}');
-
-    // lock new loads if handler detected last page (previous filteredFetched length == current length)
-    if (widget.tab.booruHandler.locked.value && !searchHandler.isLastPage.value) {
-      searchHandler.isLastPage(true);
-    }
-
+  void afterSearch() {
     // desktop view first load setter
-    if (widget.tab.booruHandler.filteredFetched.length > 0) {
-      if(widget.tab.currentItem.value.fileURL.isEmpty){
+    if ((searchHandler.currentFetched.length > 0 && searchHandler.currentFetched.length < (settingsHandler.limit + 1)) && settingsHandler.appMode == 'Desktop') {
+      if (searchHandler.viewedItem.value.fileURL.isEmpty) {
         // print("setting booruItem value");
-        widget.tab.currentItem.value = widget.tab.booruHandler.filteredFetched[0];
-        widget.tab.viewedIndex.value = 0;
+        BooruItem item = searchHandler.setViewedItem(0);
+        viewerHandler.setCurrent(item.key);
       }
     }
-    
-    // delay every new page load
-    loadingDelay = Timer(Duration(milliseconds: 200), () {
-      searchHandler.isLoading(false);
-      updateState();
-    });
-
-    updateState();
-    // this.mounted prevents an exception on first load
-
-    return;
-  }
-
-  void retryLastPage() async {
-    widget.tab.booruHandler.errorString.value = '';
-    widget.tab.booruHandler.locked.value = false;
-    searchHandler.isLastPage(false);
-    widget.tab.booruHandler.pageNum--;
-    updateState();
-    await filteredSearch();
   }
 
   void viewerCallback() {
-    viewerHandler.dropCurrent();
-    // SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: SystemUiOverlay.values);
     kbFocusNode.requestFocus();
+    viewerHandler.dropCurrent();
   }
 
-  void onThumbTap(int index) async {
+  void onTap(int index) async {
     // Load the image viewer
-    kbFocusNode.unfocus();
+
+    BooruItem item = searchHandler.setViewedItem(index);
+    viewerHandler.setCurrent(item.key);
+
     if (settingsHandler.appMode == "Mobile") {
-      viewerHandler.inViewer(true);
-      // SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: [SystemUiOverlay.bottom]);
+      kbFocusNode.unfocus();
+      viewerHandler.inViewer.value = true;
 
       await Navigator.push(
         context,
@@ -234,320 +181,8 @@ class _WaterfallState extends State<WaterfallView> {
 
       viewerCallback();
     } else {
-      widget.tab.currentItem.value = widget.tab.booruHandler.filteredFetched[index];
-      widget.tab.viewedIndex.value = index;
+      // 
     }
-  }
-
-  void onThumbDoubleTap(int index) async {
-    BooruItem item = widget.tab.booruHandler.filteredFetched[index];
-    if(item.isFavourite.value != null) {
-      ServiceHandler.vibrate();
-
-      item.isFavourite.toggle();
-      settingsHandler.dbHandler.updateBooruItem(item, "local");
-      updateState();
-    }
-  }
-
-  void onThumbLongPress(int index) async {
-    ServiceHandler.vibrate(duration: 5);
-
-    if (widget.tab.selected.contains(index)) {
-      widget.tab.selected.remove(index);
-    } else {
-      widget.tab.selected.add(index);
-    }
-    updateState();
-  }
-
-  void onThumbSecondaryTap(int index) {
-    BooruItem item = widget.tab.booruHandler.filteredFetched[index];
-    Clipboard.setData(ClipboardData(text: item.fileURL));
-    FlashElements.showSnackbar(
-      context: context,
-      duration: Duration(seconds: 2),
-      title: Text(
-        "Copied File URL to clipboard!",
-        style: TextStyle(fontSize: 20)
-      ),
-      content: Text(
-        item.fileURL,
-        style: TextStyle(fontSize: 16)
-      ),
-      leadingIcon: Icons.copy,
-      sideColor: Colors.green,
-    );
-  }
-
-  Widget cardItemBuild(int index, int columnsCount) {
-    return Obx(() {
-      bool isSelected = widget.tab.selected.contains(index);
-      bool isCurrent = settingsHandler.appMode == 'Desktop' && (widget.tab.viewedIndex.value == index);
-      return AutoScrollTag(
-        highlightColor: Colors.red,
-        key: ValueKey(index),
-        controller: searchHandler.gridScrollController,
-        index: index,
-        child: Material(
-          borderOnForeground: true,
-          child: Ink(
-            decoration: (isCurrent || isSelected)
-              ? BoxDecoration(
-                border: Border.all(
-                  color: isCurrent ? Colors.red : Get.theme.colorScheme.secondary,
-                  width: 2.0,
-                ),
-              )
-              : null,
-            child: GestureDetector(
-              onSecondaryTap: () {
-                onThumbSecondaryTap(index);
-              },
-              child: InkResponse(
-                enableFeedback: true,
-                highlightShape: BoxShape.rectangle,
-                containedInkWell: false,
-                highlightColor: Get.theme.colorScheme.secondary,
-                child: sampleorThumb(index, columnsCount, widget.tab),
-                onTap: () {
-                  onThumbTap(index);
-                },
-                onDoubleTap: () {
-                  onThumbDoubleTap(index);
-                },
-                onLongPress: () {
-                  onThumbLongPress(index);
-                },
-              ),
-            ),
-          ),
-        )
-      );
-    });
-  }
-
-  /* This will return an Image from the booruItem and will use either the sample url
-  * or the thumbnail url depending on the users settings (sampleURL is much higher quality)
-  */
-  Widget sampleorThumb(int index, int columnCount, SearchGlobal searchGlobal) {
-    BooruItem item = searchGlobal.booruHandler.filteredFetched[index];
-    IconData itemIcon = ViewUtils.getFileIcon(item.mediaType);
-
-    List<List<String>> parsedTags = settingsHandler.parseTagsList(item.tagsList, isCapped: false);
-    bool isHated = parsedTags[0].length > 0;
-    bool isLoved = parsedTags[1].length > 0;
-    bool isSound = parsedTags[2].length > 0;
-    
-    // reset the isHated value since we already check for it on every render
-    item.isHated.value = isHated;
-
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(3),
-      child: Stack(
-        alignment: settingsHandler.previewDisplay == "Square" ? Alignment.center : Alignment.bottomCenter,
-        children: [
-          CachedThumbBetter(item, index, searchGlobal, columnCount, true),
-          Container(
-            alignment: Alignment.bottomCenter,
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: [
-                // reserved for elements on the left side
-                const SizedBox(),
-
-                Container(
-                  padding: EdgeInsets.all(3),
-                  decoration: BoxDecoration(
-                    color: Colors.black.withOpacity(0.66),
-                    borderRadius: BorderRadius.only(topLeft: Radius.circular(5))
-                  ),
-                  child: Obx(() =>  Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      // Text('  ${(index + 1)}  ', style: TextStyle(fontSize: 10, color: Colors.white)),
-
-                      if(item.isFavourite.value == null)
-                        Text('.'),
-
-                      AnimatedCrossFade(
-                        duration: Duration(milliseconds: 200),
-                        crossFadeState: (item.isFavourite.value == true || isLoved) ? CrossFadeState.showFirst : CrossFadeState.showSecond,
-                        firstChild: AnimatedSwitcher(
-                          duration: Duration(milliseconds: 200),
-                          child: Icon(
-                            item.isFavourite.value == true ? Icons.favorite : Icons.star,
-                            color: item.isFavourite.value == true ? Colors.red : Colors.grey,
-                            key: ValueKey<Color>(item.isFavourite.value == true ? Colors.red : Colors.grey),
-                            size: 14,
-                          )
-                        ),
-                        secondChild: const SizedBox(),
-                      ),
-
-                      if(item.isSnatched.value == true)
-                        Icon(
-                          Icons.save_alt,
-                          color: Colors.white,
-                          size: 14,
-                        ),
-
-                      if(isSound)
-                        Icon(
-                          Icons.volume_up_rounded,
-                          color: Colors.white,
-                          size: 14,
-                        ),
-
-                      Icon(
-                        itemIcon,
-                        color: Colors.white,
-                        size: 14,
-                      ),
-                    ],
-                  )),
-                ),
-              ]
-            )
-          )
-        ]
-      )
-    );
-  }
-
-  Widget gridBuilder() {
-    return Obx(() {
-      int columnsCount =
-        (MediaQuery.of(context).orientation == Orientation.portrait)
-            ? settingsHandler.portraitColumns
-            : settingsHandler.landscapeColumns;
-
-      return GridView.builder(
-        controller: searchHandler.gridScrollController,
-        physics: const BouncingScrollPhysics(parent: const AlwaysScrollableScrollPhysics()),
-        addAutomaticKeepAlives: false,
-        cacheExtent: 200,
-        shrinkWrap: false,
-        itemCount: widget.tab.booruHandler.filteredFetched.length,
-        padding: const EdgeInsets.fromLTRB(2, 2, 2, 80),
-        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: columnsCount,
-          childAspectRatio: settingsHandler.previewDisplay == 'Square' ? 1 : 9/16
-        ),
-        itemBuilder: (BuildContext context, int index) {
-          return Card(
-            margin: EdgeInsets.all(2),
-            child: GridTile(
-              child: cardItemBuild(index, columnsCount),
-            ),
-          );
-        },
-      );
-    });
-  }
-
-  Widget staggeredBuilder() {
-    // TODO flutter upgrade to 2.0.6 seems to prevent memory overflow and stutter on new images a little, but it still won't unload things that are not in view
-    return Obx(() {
-      int columnsCount =
-        (MediaQuery.of(context).orientation == Orientation.portrait)
-            ? settingsHandler.portraitColumns
-            : settingsHandler.landscapeColumns;
-      double itemMaxWidth = MediaQuery.of(context).size.width / columnsCount;
-      double itemMaxHeight = MediaQuery.of(context).size.height * 0.6;
-
-      return StaggeredGridView.countBuilder(
-        controller: searchHandler.gridScrollController,
-        physics: const BouncingScrollPhysics(parent: const AlwaysScrollableScrollPhysics()),
-        addAutomaticKeepAlives: false,
-        shrinkWrap: false,
-        itemCount: widget.tab.booruHandler.filteredFetched.length,
-        padding: const EdgeInsets.fromLTRB(2, 2, 2, 80),
-        crossAxisCount: columnsCount,
-        itemBuilder: (BuildContext context, int index) {
-          double? widthData = widget.tab.booruHandler.filteredFetched[index].fileWidth ?? null;
-          double? heightData = widget.tab.booruHandler.filteredFetched[index].fileHeight ?? null;
-          
-          double possibleWidth = itemMaxWidth;
-          double possibleHeight = itemMaxWidth;
-          bool hasSizeData = heightData != null && widthData != null;
-          if(hasSizeData) {
-            double aspectRatio = widthData / heightData;
-            possibleHeight = possibleWidth / aspectRatio;
-          }
-          // force to use minimum 100 px and max 60% of screen height
-          possibleHeight = max(min(itemMaxHeight, possibleHeight), 100);
-          
-          return Container(
-            height: possibleHeight,
-            width: possibleWidth,
-            // constraints: hasSizeData
-            //     ? BoxConstraints(minHeight: possibleHeight, maxHeight: possibleHeight, minWidth: possibleWidth, maxWidth: possibleWidth)
-            //     : BoxConstraints(minHeight: possibleWidth, maxHeight: double.infinity, minWidth: possibleWidth, maxWidth: possibleWidth),
-            child: cardItemBuild(index, columnsCount),
-          );
-        },
-        staggeredTileBuilder: (int index) => StaggeredTile.fit(1),
-        mainAxisSpacing: 4.0,
-        crossAxisSpacing: 4.0,
-      );
-    });
-  }
-
-  Widget staggeredBetterBuilder() {
-    int columnsCount =
-      (MediaQuery.of(context).orientation == Orientation.portrait)
-          ? settingsHandler.portraitColumns
-          : settingsHandler.landscapeColumns;
-      
-    return LayoutBuilder(builder: (ctx, constraints) {
-      double itemMaxWidth = constraints.maxWidth / columnsCount; //MediaQuery.of(context).size.width / columnsCount;
-      double itemMaxHeight = itemMaxWidth * (16 / 9); //MediaQuery.of(context).size.height * 0.6;
-      return Obx(() {
-        return WaterfallFlow.builder(
-          controller: searchHandler.gridScrollController,
-          physics: const BouncingScrollPhysics(parent: const AlwaysScrollableScrollPhysics()),
-          shrinkWrap: false,
-          addAutomaticKeepAlives: false,
-          cacheExtent: 200,
-          itemCount: widget.tab.booruHandler.filteredFetched.length,
-          padding: const EdgeInsets.fromLTRB(2, 2, 2, 80),
-          gridDelegate: SliverWaterfallFlowDelegateWithFixedCrossAxisCount(
-            crossAxisCount: columnsCount,
-            mainAxisSpacing: 4.0,
-            crossAxisSpacing: 4.0,
-          ),
-          itemBuilder: (BuildContext context, int index) {
-            double? widthData = widget.tab.booruHandler.filteredFetched[index].fileWidth ?? null;
-            double? heightData = widget.tab.booruHandler.filteredFetched[index].fileHeight ?? null;
-            
-            double possibleWidth = itemMaxWidth;
-            double possibleHeight = itemMaxWidth;
-            bool hasSizeData = heightData != null && widthData != null;
-            if(hasSizeData) {
-              double aspectRatio = widthData / heightData;
-              possibleHeight = possibleWidth / aspectRatio;
-            }
-            // force to use minimum 100 px and max 60% of screen height
-            possibleHeight = max(min(itemMaxHeight, possibleHeight), 100);
-            
-            return Container(
-              height: possibleHeight,
-              width: possibleWidth,
-              // constraints: hasSizeData
-              //     ? BoxConstraints(minHeight: possibleHeight, maxHeight: possibleHeight, minWidth: possibleWidth, maxWidth: possibleWidth)
-              //     : BoxConstraints(minHeight: possibleWidth, maxHeight: double.infinity, minWidth: possibleWidth, maxWidth: possibleWidth),
-              child: cardItemBuild(index, columnsCount),
-            );
-          },
-        );
-      });
-    });
-  }
-
-  Widget wrapButton(Widget child) {
-    return Container(color: Get.theme.colorScheme.background.withOpacity(0.66), child: child);
   }
 
   @override
@@ -559,57 +194,73 @@ class _WaterfallState extends State<WaterfallView> {
       kbFocusNode.requestFocus();
     }
 
-    // print('BUILD CALL: ${widget.tab.booruHandler.filteredFetched.length}');
-
-    final String errorFormatted = widget.tab.booruHandler.errorString.isNotEmpty ? '\n${widget.tab.booruHandler.errorString}' : '';
-    final String clickName = (Platform.isWindows || Platform.isLinux) ? 'Click' : 'Tap';
-    int nowMils = DateTime.now().millisecondsSinceEpoch;
-    int sinceStart = _startedAt == 0 ? 0 : Duration(milliseconds: nowMils - _startedAt).inSeconds;
-    String sinceStartText = sinceStart > 0 ? 'Started ${sinceStart.toString()} second${sinceStart == 1 ? '' : 's'} ago' : '';
+    // print('!!! WATERFALL BUILD: ${searchHandler.currentFetched.length}');
 
     return RawKeyboardListener(
       autofocus: false,
       focusNode: kbFocusNode,
-      onKey: (RawKeyEvent event){
+      onKey: (RawKeyEvent event) {
+        // print('waterfall keyboard ${viewerHandler.inViewer.value}');
+
+        // TODO move all this higher? make global handler for hotkeys?
+        // TODO arrows move node focus around, so they are removed for now
+
         BooruItem? item;
+        int oldIndex = 0, newIndex = 0, columnCount = 0;
+
+        // detect only key DOWN events
+        // physicalKey guarantees detection on non-english keys/languages
         if (event.runtimeType == RawKeyDownEvent) {
-          if(event.isKeyPressed(LogicalKeyboardKey.arrowDown) || event.isKeyPressed(LogicalKeyboardKey.keyK) || event.isKeyPressed(LogicalKeyboardKey.keyS)) {
-            searchHandler.gridScrollController.animateTo(searchHandler.gridScrollController.offset + 50, duration: Duration(milliseconds: 50), curve: Curves.linear);
-
-          } else if(event.isKeyPressed(LogicalKeyboardKey.arrowUp) || event.isKeyPressed(LogicalKeyboardKey.keyJ) || event.isKeyPressed(LogicalKeyboardKey.keyW)) {
-            searchHandler.gridScrollController.animateTo(searchHandler.gridScrollController.offset - 50, duration: Duration(milliseconds: 50), curve: Curves.linear);
-
-          } else if(event.isKeyPressed(LogicalKeyboardKey.keyD)) {
-            final oldIndex = widget.tab.booruHandler.filteredFetched.indexWhere((el) => el == widget.tab.currentItem.value);
-            if((oldIndex + 1) < widget.tab.booruHandler.filteredFetched.length) {
-              item = widget.tab.booruHandler.filteredFetched[oldIndex + 1];
+          if(event.physicalKey == PhysicalKeyboardKey.keyK || event.physicalKey == PhysicalKeyboardKey.keyS) {
+            // searchHandler.gridScrollController.animateTo(searchHandler.gridScrollController.offset + 50, duration: Duration(milliseconds: 50), curve: Curves.linear);
+            columnCount = (MediaQuery.of(context).orientation == Orientation.portrait)
+              ? settingsHandler.portraitColumns
+              : settingsHandler.landscapeColumns;
+            oldIndex = searchHandler.viewedIndex.value;
+            newIndex = oldIndex + columnCount;
+            if(newIndex < searchHandler.currentFetched.length) {
+              item = searchHandler.setViewedItem(newIndex);
               viewerHandler.setCurrent(item.key);
-              widget.tab.currentItem.value = item;
-              widget.tab.viewedIndex.value = oldIndex + 1;
             }
 
-          } else if(event.isKeyPressed(LogicalKeyboardKey.keyA)) {
-            final oldIndex = widget.tab.booruHandler.filteredFetched.indexWhere((el) => el == widget.tab.currentItem.value);
-            if((oldIndex - 1) > -1) {
-              item = widget.tab.booruHandler.filteredFetched[oldIndex - 1];
+          } else if(event.physicalKey == PhysicalKeyboardKey.keyJ || event.physicalKey == PhysicalKeyboardKey.keyW) {
+            // searchHandler.gridScrollController.animateTo(searchHandler.gridScrollController.offset - 50, duration: Duration(milliseconds: 50), curve: Curves.linear);
+            columnCount = (MediaQuery.of(context).orientation == Orientation.portrait)
+              ? settingsHandler.portraitColumns
+              : settingsHandler.landscapeColumns;
+            oldIndex = searchHandler.viewedIndex.value;
+            newIndex = oldIndex - columnCount;
+            if(newIndex > -1) {
+              item = searchHandler.setViewedItem(newIndex);
               viewerHandler.setCurrent(item.key);
-              widget.tab.currentItem.value = item;
-              widget.tab.viewedIndex.value = oldIndex - 1;
             }
 
-          } else if(event.isKeyPressed(LogicalKeyboardKey.escape)) {
+          } else if(event.physicalKey == PhysicalKeyboardKey.keyD) {
+            oldIndex = searchHandler.viewedIndex.value;
+            newIndex = oldIndex + 1;
+            if(newIndex < searchHandler.currentFetched.length) {
+              item = searchHandler.setViewedItem(newIndex);
+              viewerHandler.setCurrent(item.key);
+            }
+
+          } else if(event.physicalKey == PhysicalKeyboardKey.keyA) {
+            oldIndex = searchHandler.viewedIndex.value;
+            newIndex = oldIndex - 1;
+            if(newIndex > -1) {
+              item = searchHandler.setViewedItem(newIndex);;
+              viewerHandler.setCurrent(item.key);
+            }
+
+          } else if(event.physicalKey == PhysicalKeyboardKey.escape) {
+            searchHandler.setViewedItem(-1);
             viewerHandler.dropCurrent();
-            widget.tab.currentItem.value = BooruItem(fileURL: '', sampleURL: '', thumbnailURL: '', tagsList: [], postURL: '');
-            // widget.tab.viewedIndex.value = 0;
-
           }
         }
       },
+
       child: Stack(
         alignment: Alignment.bottomCenter,
         children: [
-          // Obx(() => Center(child: Text('Loaded/Total: ${widget.tab.booruHandler.filteredFetched.length}/${widget.tab.booruHandler.totalCount.value}'))),
-
           NotificationListener<ScrollUpdateNotification>(
             child: Scrollbar(
               controller: searchHandler.gridScrollController,
@@ -620,10 +271,11 @@ class _WaterfallState extends State<WaterfallView> {
               child: RefreshIndicator(
                 triggerMode: RefreshIndicatorTriggerMode.anywhere,
                 displacement: 80,
+                edgeOffset: settingsHandler.appMode == 'Mobile' ? kToolbarHeight : 0,
                 strokeWidth: 4,
                 color: Get.theme.colorScheme.secondary,
                 onRefresh: () async {
-                  searchHandler.searchAction(widget.tab.tags, null);
+                  searchHandler.searchAction(searchHandler.currentTab.tags, null);
                 },
                 child: ImprovedScrolling(
                   scrollController: searchHandler.gridScrollController,
@@ -656,14 +308,14 @@ class _WaterfallState extends State<WaterfallView> {
                     scrollAmountMultiplier: 15.0,
                   ),
                   // TODO: temporary fallback to waterfall if booru doesn't give image sizes in api, until staggered view is fixed
-                  child: (settingsHandler.previewDisplay != 'Staggered' || !widget.tab.booruHandler.hasSizeData)
-                    ? gridBuilder()
-                    : staggeredBetterBuilder() //staggeredBuilder()
+                  child: (settingsHandler.previewDisplay != 'Staggered' || !searchHandler.currentBooruHandler.hasSizeData)
+                    ? GridBuilder(onTap)
+                    : StaggeredBuilder(onTap),
                 ),
               ),
             ),
             onNotification: (notif) {
-              widget.tab.scrollPosition = searchHandler.gridScrollController.offset;
+              searchHandler.updateScrollPosition();
 
               //print('SCROLL NOTIFICATION');
               //print(searchHandler.gridScrollController.position.maxScrollExtent);
@@ -675,146 +327,30 @@ class _WaterfallState extends State<WaterfallView> {
 
               if(!searchHandler.isLoading.value) {
                 if (!isScreenFilled || (isNotAtStart && isAtOrNearEdge)) {
-                  filteredSearch();
+                  // print('LOADING MORE');
+                  // print('isScreenFilled: $isScreenFilled');
+                  // print('isNotAtStart: $isNotAtStart');
+                  // print('isAtOrNearEdge: $isAtOrNearEdge');
+                  // TODO extra search could trigger when changing tabs
+                  searchHandler.runSearch();
                 }
               }
               return true;
             },
           ),
 
-          // error buttons testing
-          // Column(children: [
-          //   SettingsButton(
-          //     name: 'No Data Loaded',
-          //     subtitle: Text('$clickName Here to Reload'),
-          //     icon: Icon(Icons.refresh),
-          //     action: () {
-          //       retryLastPage();
-          //     },
+          // Obx(() => Positioned(
+          //   top: MediaQuery.of(context).size.height / 2,
+          //   left: 0,
+          //   child: Container(
+          //     color: Colors.black.withOpacity(0.5),
+          //     width: 160,
+          //     height: 30,
+          //     child: Text('L/T: ${searchHandler.currentFetched.length}/${searchHandler.currentBooruHandler.totalCount.value}'),
           //   ),
-          //   SettingsButton(
-          //     name: 'You Reached the End (${widget.tab.booruHandler.pageNum} ${widget.tab.booruHandler.pageNum.value == 1 ? 'page' : 'pages'})',
-          //     subtitle: Text('$clickName Here to Reload Last Page'),
-          //     icon: Icon(Icons.refresh),
-          //     action: () {
-          //       retryLastPage();
-          //     },
-          //   ),
-          //   SettingsButton(
-          //     name: 'Loading Page #${widget.tab.booruHandler.pageNum}',
-          //     subtitle: Text(sinceStartText),
-          //     icon: SizedBox(
-          //       width: 30,
-          //       height: 30,
-          //       child: CircularProgressIndicator(
-          //         valueColor: AlwaysStoppedAnimation(Get.theme.colorScheme.secondary)
-          //       ),
-          //     ),
-          //   ),
-          //   SettingsButton(
-          //     name: 'Error happened when Loading Page #${widget.tab.booruHandler.pageNum}:$errorFormatted',
-          //     subtitle: Text('$clickName Here to Retry'),
-          //     icon: Icon(Icons.refresh),
-          //     action: () {
-          //       retryLastPage();
-          //     },
-          //   ),
-          //   SettingsButton(
-          //     name: 'Error, no data loaded:',
-          //     subtitle: Text('$clickName Here to Retry'),
-          //     icon: Icon(Icons.refresh),
-          //     action: () {
-          //       retryLastPage();
-          //     },
-          //   ),
-          // ]),
+          // )),
 
-          Obx(() {
-            if(searchHandler.isLastPage.value) {
-              // if last page...
-              if(widget.tab.booruHandler.filteredFetched.length == 0) {
-                // ... and no items loaded
-                return wrapButton(SettingsButton(
-                  name: 'No Data Loaded',
-                  subtitle: Text('$clickName Here to Reload'),
-                  icon: Icon(Icons.refresh),
-                  dense: true,
-                  action: () {
-                    retryLastPage();
-                  },
-                  drawBottomBorder: false,
-                ));
-              } else { //if(widget.tab.booruHandler.filteredFetched.length > 0) {
-                // .. has items loaded
-                return wrapButton(SettingsButton(
-                  name: 'You Reached the End (${widget.tab.booruHandler.pageNum} ${widget.tab.booruHandler.pageNum.value == 1 ? 'page' : 'pages'})',
-                  subtitle: Text('$clickName Here to Reload Last Page'),
-                  icon: Icon(Icons.refresh),
-                  dense: true,
-                  action: () {
-                    retryLastPage();
-                  },
-                  drawBottomBorder: false,
-                ));
-              }
-            } else {
-              // if not last page...
-              if(searchHandler.isLoading.value) {
-                // ... and is currently loading
-                return wrapButton(SettingsButton(
-                  name: 'Loading Page #${widget.tab.booruHandler.pageNum}',
-                  subtitle: AnimatedOpacity(
-                    opacity: sinceStartText.isNotEmpty ? 1.0 : 0.0,
-                    duration: const Duration(milliseconds: 200),
-                    child: Text(sinceStartText),
-                  ),
-                  icon: SizedBox(
-                    width: 30,
-                    height: 30,
-                    child: CircularProgressIndicator(
-                      valueColor: AlwaysStoppedAnimation(Get.theme.colorScheme.secondary)
-                    ),
-                  ),
-                  dense: true,
-                  action: () {
-                    retryLastPage();
-                  },
-                  drawBottomBorder: false,
-                ));
-              } else {
-                if (widget.tab.booruHandler.errorString.isNotEmpty) {
-                  // ... if error happened
-                  return wrapButton(SettingsButton(
-                    name: 'Error happened when Loading Page #${widget.tab.booruHandler.pageNum}:${errorFormatted}',
-                    subtitle: Text('$clickName Here to Retry'),
-                    icon: Icon(Icons.refresh),
-                    dense: true,
-                    action: () {
-                      retryLastPage();
-                    },
-                    drawBottomBorder: false,
-                  ));
-                } else if(widget.tab.booruHandler.filteredFetched.length == 0) {
-                  // ... no items loaded
-                  return wrapButton(SettingsButton(
-                    name: 'Error, no data loaded:',
-                    subtitle: Text('$clickName Here to Retry'),
-                    icon: Icon(Icons.refresh),
-                    dense: true,
-                    action: () {
-                      retryLastPage();
-                    },
-                    drawBottomBorder: false,
-                  ));
-                } else {
-                  // return const SizedBox.shrink();
-
-                  // add a small container to avoid scrolling when swiping from the bottom of the screen (navigation gestures)
-                  return Container(height: 10, color: Colors.transparent);
-                }
-              }
-            }
-          }),
+          WaterfallErrorButtons(),
         ],
       )
     );

--- a/lib/widgets/ZoomButton.dart
+++ b/lib/widgets/ZoomButton.dart
@@ -17,25 +17,25 @@ class _ZoomButtonState extends State<ZoomButton> {
   final SettingsHandler settingsHandler = Get.find<SettingsHandler>();
   final ViewerHandler viewerHandler = Get.find<ViewerHandler>();
 
-  bool isZoomButtonVisible = false;
+  bool isVisible = false;
 
   StreamSubscription<bool>? appbarListener;
 
   @override
   void initState() {
     super.initState();
-    isZoomButtonVisible = settingsHandler.zoomButtonPosition != "Disabled" && settingsHandler.appMode != "Desktop";
+    isVisible = settingsHandler.zoomButtonPosition != "Disabled" && settingsHandler.appMode != "Desktop" && viewerHandler.displayAppbar.value;
     appbarListener = viewerHandler.displayAppbar.listen((bool value) {
-      if(settingsHandler.zoomButtonPosition != "Disabled" && settingsHandler.appMode != "Desktop") {
-        isZoomButtonVisible = value;
+      if (settingsHandler.zoomButtonPosition != "Disabled" && settingsHandler.appMode != "Desktop") {
+        isVisible = value;
       }
       updateState();
     });
   }
 
   void updateState() {
-    if(this.mounted) {
-      setState(() { });
+    if (this.mounted) {
+      setState(() {});
     }
   }
 
@@ -47,25 +47,25 @@ class _ZoomButtonState extends State<ZoomButton> {
 
   @override
   Widget build(BuildContext context) {
-    if(isZoomButtonVisible) {
-      return Obx(() => Positioned(
+    if (isVisible) {
+      return Positioned(
         bottom: kToolbarHeight * 3,
         right: settingsHandler.zoomButtonPosition == "Right" ? -10 : null,
         left: settingsHandler.zoomButtonPosition == "Left" ? -10 : null,
         child: ElevatedButton(
           style: ElevatedButton.styleFrom(
-            primary: Get.theme.colorScheme.secondary.withOpacity(0.33),
+            primary: Get.theme.colorScheme.background.withOpacity(0.33),
             minimumSize: Size(28, 28),
             padding: EdgeInsets.all(3),
           ),
-          child: Icon(
-            viewerHandler.isZoomed.value ? Icons.zoom_out : Icons.zoom_in,
-            size: 28,
-            color: Get.theme.colorScheme.onSecondary
-          ),
+          child: Obx(() => Icon(
+                viewerHandler.isZoomed.value ? Icons.zoom_out : Icons.zoom_in,
+                size: 28,
+                color: Get.theme.colorScheme.onBackground.withOpacity(0.5),
+              )),
           onPressed: viewerHandler.toggleZoom,
-        )
-      ));
+        ),
+      );
     } else {
       return const SizedBox();
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,10 +28,10 @@ dependencies:
   intl: ^0.17.0
   uuid: ^3.0.5
   package_info_plus: ^1.3.0
-  path_provider: ^2.0.7
+  path_provider: ^2.0.8
   app_links: ^2.2.0
   flex_color_picker: ^2.2.0
-  flash: ^2.0.3
+  flash: ^2.0.3+1
   dropdown_search: ^2.0.1
   marquee: ^2.2.0
   fast_marquee:
@@ -41,10 +41,10 @@ dependencies:
   flutter_linkify: ^5.0.2
   statsfl: ^2.0.1+1
   vibration: ^1.7.4-nullsafety.0
-  get: ^4.3.8
+  get: ^4.6.1
   permission_handler: ^8.1.6 # next update will require android sdk version 31
-  image: ^3.0.8
-  google_fonts: ^2.1.0
+  image: ^3.1.0
+  google_fonts: ^2.1.1
   photo_view: # ^0.12.0
     git:
       url: "https://github.com/NANI-SORE/photo_view.git"
@@ -52,21 +52,21 @@ dependencies:
   flutter_staggered_grid_view: # ^0.4.0
     git:
       url: "https://github.com/bladeofgod/flutter_staggered_grid_view.git"
-  waterfall_flow: ^3.0.1
-  scroll_to_index: ^2.1.0
+  waterfall_flow: ^3.0.2
+  scroll_to_index: ^2.1.1
   flutter_inner_drawer:
     git:
       url: "https://github.com/NANI-SORE/flutter_inner_drawer.git"
   transparent_image: ^2.0.0
-  video_player: ^2.2.7
+  video_player: ^2.2.10
   dart_vlc: ^0.1.8
   chewie: ^1.2.2
-  sqflite: ^2.0.0+4
+  sqflite: ^2.0.1
   sqflite_common_ffi: ^2.1.0
   preload_page_view: ^0.1.6
   flutter_displaymode: ^0.3.2
   crypto: ^3.0.1
-  keyboard_actions: ^3.4.4
+  keyboard_actions: ^3.4.5
   flutter_improved_scrolling: ^0.0.3
 
 flutter_icons:

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
-project(test_flutter LANGUAGES CXX)
+project(lolisnatcher LANGUAGES CXX)
 
-set(BINARY_NAME "test_flutter")
+set(BINARY_NAME "lolisnatcher")
 
 cmake_policy(SET CMP0063 NEW)
 

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -89,13 +89,13 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "com.example" "\0"
+            VALUE "CompanyName", "com.noaisu" "\0"
             VALUE "FileDescription", "A new Flutter project." "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "test_flutter" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2021 com.example. All rights reserved." "\0"
-            VALUE "OriginalFilename", "test_flutter.exe" "\0"
-            VALUE "ProductName", "test_flutter" "\0"
+            VALUE "InternalName", "lolisnatcher" "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2021 com.noaisu. All rights reserved." "\0"
+            VALUE "OriginalFilename", "lolisnatcher.exe" "\0"
+            VALUE "ProductName", "lolisnatcher" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -44,7 +44,7 @@ LRESULT
 FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
                               WPARAM const wparam,
                               LPARAM const lparam) noexcept {
-  // Give Flutter, including plugins, an opporutunity to handle window messages.
+  // Give Flutter, including plugins, an opportunity to handle window messages.
   if (flutter_controller_) {
     std::optional<LRESULT> result =
         flutter_controller_->HandleTopLevelWindowProc(hwnd, message, wparam,

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -30,7 +30,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(&run_loop, project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.CreateAndShow(L"test_flutter", origin, size)) {
+  if (!window.CreateAndShow(L"lolisnatcher", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
- Updated to Flutter 2.8.1
- Updated some dependencies
- Changed/rewritten a bunch of widgets to be much more performant
- Notes overlay
-- available on: sankaku, gelbooru
- main appbar now hides when grid is scrolled
- added jump to/search until specific page dialog in the main appbar
- improved snatch progress messages
- improved favourites db fetch speed
- added site filter to favourites "booru"
-- example: 'site:chan' will find all items with 'chan' in post url
- fixed autocomplete for .xyz/.world
- text fields now can have done, clear and reset buttons
- numeric input fields can have limits and quick edit buttons
-- (these buttons also support long press)
- added change page buttons to viewer (disabled by default, see gallery settings)
- fixed tab and booru selectors not scrolling to the selected item
- added a placeholder for unsupported file formats
- you can now resize parts of desktop mode views
- don't auto downalod media if it's bigger than 200mb
-- (will probably become a setting in the future)
- fixed keyboard hotkeys not working with non-english keys

- Lolisync changes:
-- changed default port to 8080
-- new feature - tab syncing (merge or replace)
-- allow to skip custom amount of favourites
-- show last 10 completed actions

--- other small changes and fixes...